### PR TITLE
feat: implement AuthenticateRequest and VerifyToken JWKS helpers

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -13,8 +13,10 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 csharp:
-  version: 0.2.1
-  additionalDependencies: []
+  version: 0.2.2
+  additionalDependencies:
+    - package: System.IdentityModel.Tokens.Jwt
+      version: 8.2.0
   author: Clerk
   clientServerStatusCodesAsErrors: true
   defaultErrorName: SDKError

--- a/src/Clerk/BackendAPI/.genignore
+++ b/src/Clerk/BackendAPI/.genignore
@@ -1,0 +1,1 @@
+Helpers/

--- a/src/Clerk/BackendAPI/Clerk.BackendAPI.csproj
+++ b/src/Clerk/BackendAPI/Clerk.BackendAPI.csproj
@@ -44,6 +44,7 @@ Please see https://clerk.com/docs for more information.</Description>
   <ItemGroup>
     <PackageReference Include="newtonsoft.json" Version="13.0.3" />
     <PackageReference Include="nodatime" Version="3.1.9" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequest.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequest.cs
@@ -1,0 +1,117 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+
+
+    /// <summary>
+    /// AuthenticateRequest - Helper methods to authenticate requests.
+    /// </summary>
+    public static class AuthenticateRequest
+    {
+        private const string SESSION_COOKIE_NAME = "__session";
+
+        /// <summary>
+        /// Checks if the HTTP request is authenticated.
+        ///
+        /// First the session token is retrieved from either the __session cookie
+        /// or the HTTP Authorization header.
+        /// Then the session token is verified: networklessly if the options.jwtKey
+        /// is provided, otherwise by fetching the JWKS from Clerk's Backend API.
+        /// </summary>
+        /// <param name="request">The HTTP request</param>
+        /// <param name="options">The request authentication options</param>
+        /// <returns>The request state</returns>
+        /// <remarks>WARNING: authenticateRequest is applicable in the context of Backend APIs only.</remarks>
+        public static async Task<RequestState> AuthenticateRequestAsync(HttpRequestMessage request, AuthenticateRequestOptions options)
+        {
+            string? sessionToken = GetSessionToken(request);
+            if (sessionToken == null)
+            {
+                return RequestState.SignedOut(AuthErrorReason.SESSION_TOKEN_MISSING);
+            }
+
+            VerifyTokenOptions verifyTokenOptions;
+
+            if (options.JwtKey != null)
+            {
+                verifyTokenOptions = new VerifyTokenOptions(
+                    jwtKey: options.JwtKey,
+                    audiences: options.Audiences,
+                    authorizedParties: options.AuthorizedParties,
+                    clockSkewInMs: options.ClockSkewInMs
+                );
+            }
+            else if (options.SecretKey != null)
+            {
+                verifyTokenOptions = new VerifyTokenOptions(
+                    secretKey: options.SecretKey,
+                    audiences: options.Audiences,
+                    authorizedParties: options.AuthorizedParties,
+                    clockSkewInMs: options.ClockSkewInMs
+                );
+            }
+            else
+            {
+                return RequestState.SignedOut(AuthErrorReason.SECRET_KEY_MISSING);
+            }
+
+            try
+            {
+                var claims = await VerifyToken.VerifyTokenAsync(sessionToken, verifyTokenOptions);
+                return RequestState.SignedIn(sessionToken, claims);
+            }
+            catch (TokenVerificationException e)
+            {
+                return RequestState.SignedOut(e.Reason);
+            }
+
+        }
+
+        /// <summary>
+        /// Retrieve token from __session cookie or Authorization header.
+        /// </summary>
+        /// <param name="request">The HTTP request</param>
+        /// <returns>The session token, if present</returns>
+        private static string? GetSessionToken(HttpRequestMessage request)
+        {
+            if (request.Headers.TryGetValues("Authorization", out var authorizationHeaders))
+            {
+                var bearerToken = authorizationHeaders.FirstOrDefault();
+                if (!string.IsNullOrEmpty(bearerToken))
+                {
+                    return bearerToken.Replace("Bearer ", "");
+                }
+            }
+
+            if (request.Headers.TryGetValues("Cookie", out var cookieHeaders))
+            {
+                var cookieHeaderValue = cookieHeaders.FirstOrDefault();
+                if (!string.IsNullOrEmpty(cookieHeaderValue))
+                {
+                    var cookies = cookieHeaderValue.Split(';')
+                        .Select(cookie => cookie.Trim())
+                        .Select(cookie => new Cookie(cookie.Split('=')[0], cookie.Split('=')[1]));
+
+                    foreach (var cookie in cookies)
+                    {
+                        if (cookie.Name == SESSION_COOKIE_NAME)
+                        {
+                            return cookie.Value;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+
+}
+

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequest.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequest.cs
@@ -1,117 +1,93 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Threading.Tasks;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+/// <summary>
+///     AuthenticateRequest - Helper methods to authenticate requests.
+/// </summary>
+public static class AuthenticateRequest
+{
+    private const string SESSION_COOKIE_NAME = "__session";
 
     /// <summary>
-    /// AuthenticateRequest - Helper methods to authenticate requests.
+    ///     Checks if the HTTP request is authenticated.
+    ///     First the session token is retrieved from either the __session cookie
+    ///     or the HTTP Authorization header.
+    ///     Then the session token is verified: networklessly if the options.jwtKey
+    ///     is provided, otherwise by fetching the JWKS from Clerk's Backend API.
     /// </summary>
-    public static class AuthenticateRequest
+    /// <param name="request">The HTTP request</param>
+    /// <param name="options">The request authentication options</param>
+    /// <returns>The request state</returns>
+    /// <remarks>WARNING: AuthenticateRequestAsync is applicable in the context of Backend APIs only.</remarks>
+    public static async Task<RequestState> AuthenticateRequestAsync(
+        HttpRequestMessage request,
+        AuthenticateRequestOptions options)
     {
-        private const string SESSION_COOKIE_NAME = "__session";
+        var sessionToken = GetSessionToken(request);
+        if (sessionToken == null) return RequestState.SignedOut(AuthErrorReason.SESSION_TOKEN_MISSING);
 
-        /// <summary>
-        /// Checks if the HTTP request is authenticated.
-        ///
-        /// First the session token is retrieved from either the __session cookie
-        /// or the HTTP Authorization header.
-        /// Then the session token is verified: networklessly if the options.jwtKey
-        /// is provided, otherwise by fetching the JWKS from Clerk's Backend API.
-        /// </summary>
-        /// <param name="request">The HTTP request</param>
-        /// <param name="options">The request authentication options</param>
-        /// <returns>The request state</returns>
-        /// <remarks>WARNING: authenticateRequest is applicable in the context of Backend APIs only.</remarks>
-        public static async Task<RequestState> AuthenticateRequestAsync(HttpRequestMessage request, AuthenticateRequestOptions options)
+        VerifyTokenOptions verifyTokenOptions;
+
+        if (options.JwtKey != null)
+            verifyTokenOptions = new VerifyTokenOptions(
+                jwtKey: options.JwtKey,
+                audiences: options.Audiences,
+                authorizedParties: options.AuthorizedParties,
+                clockSkewInMs: options.ClockSkewInMs
+            );
+        else if (options.SecretKey != null)
+            verifyTokenOptions = new VerifyTokenOptions(
+                options.SecretKey,
+                audiences: options.Audiences,
+                authorizedParties: options.AuthorizedParties,
+                clockSkewInMs: options.ClockSkewInMs
+            );
+        else
+            return RequestState.SignedOut(AuthErrorReason.SECRET_KEY_MISSING);
+
+        try
         {
-            string? sessionToken = GetSessionToken(request);
-            if (sessionToken == null)
-            {
-                return RequestState.SignedOut(AuthErrorReason.SESSION_TOKEN_MISSING);
-            }
-
-            VerifyTokenOptions verifyTokenOptions;
-
-            if (options.JwtKey != null)
-            {
-                verifyTokenOptions = new VerifyTokenOptions(
-                    jwtKey: options.JwtKey,
-                    audiences: options.Audiences,
-                    authorizedParties: options.AuthorizedParties,
-                    clockSkewInMs: options.ClockSkewInMs
-                );
-            }
-            else if (options.SecretKey != null)
-            {
-                verifyTokenOptions = new VerifyTokenOptions(
-                    secretKey: options.SecretKey,
-                    audiences: options.Audiences,
-                    authorizedParties: options.AuthorizedParties,
-                    clockSkewInMs: options.ClockSkewInMs
-                );
-            }
-            else
-            {
-                return RequestState.SignedOut(AuthErrorReason.SECRET_KEY_MISSING);
-            }
-
-            try
-            {
-                var claims = await VerifyToken.VerifyTokenAsync(sessionToken, verifyTokenOptions);
-                return RequestState.SignedIn(sessionToken, claims);
-            }
-            catch (TokenVerificationException e)
-            {
-                return RequestState.SignedOut(e.Reason);
-            }
-
+            var claims = await VerifyToken.VerifyTokenAsync(sessionToken, verifyTokenOptions);
+            return RequestState.SignedIn(sessionToken, claims);
         }
-
-        /// <summary>
-        /// Retrieve token from __session cookie or Authorization header.
-        /// </summary>
-        /// <param name="request">The HTTP request</param>
-        /// <returns>The session token, if present</returns>
-        private static string? GetSessionToken(HttpRequestMessage request)
+        catch (TokenVerificationException e)
         {
-            if (request.Headers.TryGetValues("Authorization", out var authorizationHeaders))
-            {
-                var bearerToken = authorizationHeaders.FirstOrDefault();
-                if (!string.IsNullOrEmpty(bearerToken))
-                {
-                    return bearerToken.Replace("Bearer ", "");
-                }
-            }
-
-            if (request.Headers.TryGetValues("Cookie", out var cookieHeaders))
-            {
-                var cookieHeaderValue = cookieHeaders.FirstOrDefault();
-                if (!string.IsNullOrEmpty(cookieHeaderValue))
-                {
-                    var cookies = cookieHeaderValue.Split(';')
-                        .Select(cookie => cookie.Trim())
-                        .Select(cookie => new Cookie(cookie.Split('=')[0], cookie.Split('=')[1]));
-
-                    foreach (var cookie in cookies)
-                    {
-                        if (cookie.Name == SESSION_COOKIE_NAME)
-                        {
-                            return cookie.Value;
-                        }
-                    }
-                }
-            }
-
-            return null;
+            return RequestState.SignedOut(e.Reason);
         }
     }
 
-}
+    /// <summary>
+    ///     Retrieve token from __session cookie or Authorization header.
+    /// </summary>
+    /// <param name="request">The HTTP request</param>
+    /// <returns>The session token, if present</returns>
+    private static string? GetSessionToken(HttpRequestMessage request)
+    {
+        if (request.Headers.TryGetValues("Authorization", out var authorizationHeaders))
+        {
+            var bearerToken = authorizationHeaders.FirstOrDefault();
+            if (!string.IsNullOrEmpty(bearerToken)) return bearerToken.Replace("Bearer ", "");
+        }
 
+        if (request.Headers.TryGetValues("Cookie", out var cookieHeaders))
+        {
+            var cookieHeaderValue = cookieHeaders.FirstOrDefault();
+            if (!string.IsNullOrEmpty(cookieHeaderValue))
+            {
+                var cookies = cookieHeaderValue.Split(';')
+                    .Select(cookie => cookie.Trim())
+                    .Select(cookie => new Cookie(cookie.Split('=')[0], cookie.Split('=')[1]));
+
+                foreach (var cookie in cookies)
+                    if (cookie.Name == SESSION_COOKIE_NAME)
+                        return cookie.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequestException.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequestException.cs
@@ -1,0 +1,44 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+
+
+    public static class AuthErrorReason
+    {
+        public static readonly ErrorReason
+            SESSION_TOKEN_MISSING = new ErrorReason(
+                "session-token-missing",
+                "Could not retrieve session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT"
+            ),
+            SECRET_KEY_MISSING = new ErrorReason(
+                "secret-key-missing",
+                "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
+            );
+    }
+
+    public class AuthenticateRequestException : Exception
+    {
+        public readonly ErrorReason Reason;
+
+        public AuthenticateRequestException(ErrorReason reason) : base(reason.Message)
+        {
+            this.Reason = reason;
+        }
+
+        public AuthenticateRequestException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
+        {
+            this.Reason = reason;
+        }
+
+        public override string ToString()
+        {
+            return this.Reason.Message;
+        }
+    }
+
+}

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequestException.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequestException.cs
@@ -1,44 +1,36 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+public static class AuthErrorReason
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
+    public static readonly ErrorReason
+        SESSION_TOKEN_MISSING = new(
+            "session-token-missing",
+            "Could not retrieve session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT"
+        ),
+        SECRET_KEY_MISSING = new(
+            "secret-key-missing",
+            "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
+        );
+}
 
+public class AuthenticateRequestException : Exception
+{
+    public readonly ErrorReason Reason;
 
-    public static class AuthErrorReason
+    public AuthenticateRequestException(ErrorReason reason) : base(reason.Message)
     {
-        public static readonly ErrorReason
-            SESSION_TOKEN_MISSING = new ErrorReason(
-                "session-token-missing",
-                "Could not retrieve session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT"
-            ),
-            SECRET_KEY_MISSING = new ErrorReason(
-                "secret-key-missing",
-                "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
-            );
+        Reason = reason;
     }
 
-    public class AuthenticateRequestException : Exception
+    public AuthenticateRequestException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
     {
-        public readonly ErrorReason Reason;
-
-        public AuthenticateRequestException(ErrorReason reason) : base(reason.Message)
-        {
-            this.Reason = reason;
-        }
-
-        public AuthenticateRequestException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
-        {
-            this.Reason = reason;
-        }
-
-        public override string ToString()
-        {
-            return this.Reason.Message;
-        }
+        Reason = reason;
     }
 
+    public override string ToString()
+    {
+        return Reason.Message;
+    }
 }

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequestOptions.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequestOptions.cs
@@ -1,0 +1,58 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using Clerk.BackendAPI;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+
+    public sealed class AuthenticateRequestOptions
+    {
+        private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
+
+        public readonly string? SecretKey;
+        public readonly string? JwtKey;
+        public readonly IEnumerable<string>? Audiences;
+        public readonly IEnumerable<string> AuthorizedParties;
+        public readonly long ClockSkewInMs;
+
+        /// <summary>
+        /// Options to configure AuthenticateRequest.
+        ///
+        /// </summary>
+        /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
+        /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
+        /// <param name="audiences">A list of audiences to verify against.</param>
+        /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
+        /// <param name="clockSkewInMs">Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.</param>
+        public AuthenticateRequestOptions(
+            string? secretKey = null,
+            string? jwtKey = null,
+            ClerkBackendApi? sdk = null,
+            IEnumerable<string>? audiences = null,
+            IEnumerable<string>? authorizedParties = null,
+            long? clockSkewInMs = null)
+        {
+            if (sdk != null)
+            {
+
+            }
+            if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
+            {
+                if (sdk == null)
+                {
+                    throw new AuthenticateRequestException(AuthErrorReason.SECRET_KEY_MISSING);
+                }
+            }
+
+            SecretKey = secretKey;
+            JwtKey = jwtKey;
+            Audiences = audiences;
+            AuthorizedParties = authorizedParties ?? new List<string>();
+            ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
+        }
+    }
+
+}

--- a/src/Clerk/BackendAPI/Helpers/AuthenticateRequestOptions.cs
+++ b/src/Clerk/BackendAPI/Helpers/AuthenticateRequestOptions.cs
@@ -1,58 +1,42 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System.Collections.Generic;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+public sealed class AuthenticateRequestOptions
 {
-    using Clerk.BackendAPI;
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
+    private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
+    public readonly IEnumerable<string>? Audiences;
+    public readonly IEnumerable<string> AuthorizedParties;
+    public readonly long ClockSkewInMs;
+    public readonly string? JwtKey;
 
-    public sealed class AuthenticateRequestOptions
+    public readonly string? SecretKey;
+
+    /// <summary>
+    ///     Options to configure AuthenticateRequestAsync.
+    /// </summary>
+    /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
+    /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
+    /// <param name="audiences">A list of audiences to verify against.</param>
+    /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
+    /// <param name="clockSkewInMs">
+    ///     Allowed time difference (in milliseconds) between the Clerk server (which generates the
+    ///     token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.
+    /// </param>
+    public AuthenticateRequestOptions(
+        string? secretKey = null,
+        string? jwtKey = null,
+        IEnumerable<string>? audiences = null,
+        IEnumerable<string>? authorizedParties = null,
+        long? clockSkewInMs = null)
     {
-        private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
+        if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
+            throw new AuthenticateRequestException(AuthErrorReason.SECRET_KEY_MISSING);
 
-        public readonly string? SecretKey;
-        public readonly string? JwtKey;
-        public readonly IEnumerable<string>? Audiences;
-        public readonly IEnumerable<string> AuthorizedParties;
-        public readonly long ClockSkewInMs;
-
-        /// <summary>
-        /// Options to configure AuthenticateRequest.
-        ///
-        /// </summary>
-        /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
-        /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
-        /// <param name="audiences">A list of audiences to verify against.</param>
-        /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
-        /// <param name="clockSkewInMs">Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.</param>
-        public AuthenticateRequestOptions(
-            string? secretKey = null,
-            string? jwtKey = null,
-            ClerkBackendApi? sdk = null,
-            IEnumerable<string>? audiences = null,
-            IEnumerable<string>? authorizedParties = null,
-            long? clockSkewInMs = null)
-        {
-            if (sdk != null)
-            {
-
-            }
-            if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
-            {
-                if (sdk == null)
-                {
-                    throw new AuthenticateRequestException(AuthErrorReason.SECRET_KEY_MISSING);
-                }
-            }
-
-            SecretKey = secretKey;
-            JwtKey = jwtKey;
-            Audiences = audiences;
-            AuthorizedParties = authorizedParties ?? new List<string>();
-            ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
-        }
+        SecretKey = secretKey;
+        JwtKey = jwtKey;
+        Audiences = audiences;
+        AuthorizedParties = authorizedParties ?? new List<string>();
+        ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
     }
-
 }

--- a/src/Clerk/BackendAPI/Helpers/ErrorReason.cs
+++ b/src/Clerk/BackendAPI/Helpers/ErrorReason.cs
@@ -1,0 +1,25 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+
+
+    /// <summary>
+    /// Represents the reason for a TokenVerificationException or AuthenticateRequestException
+    /// </summary>
+    public class ErrorReason
+    {
+        public readonly string Id;
+        public readonly string Message;
+
+        public ErrorReason(string id, string message)
+        {
+            this.Id = id;
+            this.Message = message;
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Helpers/ErrorReason.cs
+++ b/src/Clerk/BackendAPI/Helpers/ErrorReason.cs
@@ -1,25 +1,16 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+/// <summary>
+///     Represents the reason for a TokenVerificationException or AuthenticateRequestException.
+/// </summary>
+public class ErrorReason
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
+    public readonly string Id;
+    public readonly string Message;
 
-
-    /// <summary>
-    /// Represents the reason for a TokenVerificationException or AuthenticateRequestException
-    /// </summary>
-    public class ErrorReason
+    public ErrorReason(string id, string message)
     {
-        public readonly string Id;
-        public readonly string Message;
-
-        public ErrorReason(string id, string message)
-        {
-            this.Id = id;
-            this.Message = message;
-        }
+        Id = id;
+        Message = message;
     }
 }

--- a/src/Clerk/BackendAPI/Helpers/RequestState.cs
+++ b/src/Clerk/BackendAPI/Helpers/RequestState.cs
@@ -1,0 +1,75 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+
+    /// <summary>
+    /// AuthStatus - The request authentication status.
+    /// </summary>
+    public class AuthStatus
+    {
+        public static readonly AuthStatus SignedIn = new AuthStatus("signed-in");
+        public static readonly AuthStatus SignedOut = new AuthStatus("signed-out");
+
+        private readonly string value;
+
+        private AuthStatus(string value)
+        {
+            this.value = value;
+        }
+
+        public string Value()
+        {
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// RequestState - Authentication State of the request.
+    /// </summary>
+    public class RequestState
+    {
+        public readonly AuthStatus Status;
+        public readonly ErrorReason? ErrorReason;
+        public readonly string? Token;
+        public readonly ClaimsPrincipal? Claims;
+
+
+        public RequestState(AuthStatus status,
+                            ErrorReason? errorReason,
+                            string? token,
+                            ClaimsPrincipal? claims)
+        {
+            Status = status;
+            ErrorReason = errorReason;
+            Token = token;
+            Claims = claims;
+        }
+
+        public static RequestState SignedIn(string token, ClaimsPrincipal claims)
+        {
+            return new RequestState(AuthStatus.SignedIn, null, token, claims);
+        }
+
+        public static RequestState SignedOut(ErrorReason errorReason)
+        {
+            return new RequestState(AuthStatus.SignedOut, errorReason, null, null);
+        }
+
+        public bool IsSignedIn()
+        {
+            return Status == AuthStatus.SignedIn;
+        }
+
+        public bool IsSignedOut()
+        {
+            return Status == AuthStatus.SignedOut;
+        }
+    }
+
+}

--- a/src/Clerk/BackendAPI/Helpers/RequestState.cs
+++ b/src/Clerk/BackendAPI/Helpers/RequestState.cs
@@ -1,75 +1,67 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System.Security.Claims;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+/// <summary>
+///     AuthStatus - The request authentication status.
+/// </summary>
+public class AuthStatus
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading;
+    public static readonly AuthStatus SignedIn = new("signed-in");
+    public static readonly AuthStatus SignedOut = new("signed-out");
 
-    /// <summary>
-    /// AuthStatus - The request authentication status.
-    /// </summary>
-    public class AuthStatus
+    private readonly string value;
+
+    private AuthStatus(string value)
     {
-        public static readonly AuthStatus SignedIn = new AuthStatus("signed-in");
-        public static readonly AuthStatus SignedOut = new AuthStatus("signed-out");
-
-        private readonly string value;
-
-        private AuthStatus(string value)
-        {
-            this.value = value;
-        }
-
-        public string Value()
-        {
-            return value;
-        }
+        this.value = value;
     }
 
-    /// <summary>
-    /// RequestState - Authentication State of the request.
-    /// </summary>
-    public class RequestState
+    public string Value()
     {
-        public readonly AuthStatus Status;
-        public readonly ErrorReason? ErrorReason;
-        public readonly string? Token;
-        public readonly ClaimsPrincipal? Claims;
+        return value;
+    }
+}
+
+/// <summary>
+///     RequestState - Authentication State of the request.
+/// </summary>
+public class RequestState
+{
+    public readonly ClaimsPrincipal? Claims;
+    public readonly ErrorReason? ErrorReason;
+    public readonly AuthStatus Status;
+    public readonly string? Token;
 
 
-        public RequestState(AuthStatus status,
-                            ErrorReason? errorReason,
-                            string? token,
-                            ClaimsPrincipal? claims)
-        {
-            Status = status;
-            ErrorReason = errorReason;
-            Token = token;
-            Claims = claims;
-        }
-
-        public static RequestState SignedIn(string token, ClaimsPrincipal claims)
-        {
-            return new RequestState(AuthStatus.SignedIn, null, token, claims);
-        }
-
-        public static RequestState SignedOut(ErrorReason errorReason)
-        {
-            return new RequestState(AuthStatus.SignedOut, errorReason, null, null);
-        }
-
-        public bool IsSignedIn()
-        {
-            return Status == AuthStatus.SignedIn;
-        }
-
-        public bool IsSignedOut()
-        {
-            return Status == AuthStatus.SignedOut;
-        }
+    public RequestState(AuthStatus status,
+        ErrorReason? errorReason,
+        string? token,
+        ClaimsPrincipal? claims)
+    {
+        Status = status;
+        ErrorReason = errorReason;
+        Token = token;
+        Claims = claims;
     }
 
+    public static RequestState SignedIn(string token, ClaimsPrincipal claims)
+    {
+        return new RequestState(AuthStatus.SignedIn, null, token, claims);
+    }
+
+    public static RequestState SignedOut(ErrorReason errorReason)
+    {
+        return new RequestState(AuthStatus.SignedOut, errorReason, null, null);
+    }
+
+    public bool IsSignedIn()
+    {
+        return Status == AuthStatus.SignedIn;
+    }
+
+    public bool IsSignedOut()
+    {
+        return Status == AuthStatus.SignedOut;
+    }
 }

--- a/src/Clerk/BackendAPI/Helpers/TokenVerificationException.cs
+++ b/src/Clerk/BackendAPI/Helpers/TokenVerificationException.cs
@@ -1,0 +1,86 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+
+    public class TokenVerificationException : Exception
+    {
+        public readonly ErrorReason Reason;
+
+        public TokenVerificationException(ErrorReason reason) : base(reason.Message)
+        {
+            this.Reason = reason;
+        }
+
+        public TokenVerificationException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
+        {
+            this.Reason = reason;
+        }
+
+        public override string ToString()
+        {
+            return this.Reason.Message;
+        }
+    }
+
+    public static class TokenVerificationErrorReason
+    {
+        public static readonly ErrorReason
+            JWK_FAILED_TO_LOAD = new ErrorReason(
+                "jwk-failed-to-load",
+                "Failed to load JWKS from Clerk Backend API. Contact support@clerk.com."
+            ),
+            JWK_REMOTE_INVALID = new ErrorReason(
+                "jwk-remote-invalid",
+                "The JWKS endpoint did not contain any signing keys. Contact support@clerk.com."
+            ),
+            JWK_LOCAL_INVALID = new ErrorReason(
+                "jwk-local-invalid",
+                "The provided PEM Public Key is not in the proper format."
+            ),
+            JWK_FAILED_TO_RESOLVE = new ErrorReason(
+                "jwk-failed-to-resolve",
+                "Failed to resolve JWK. Public Key is not in the proper format."
+            ),
+            JWK_KID_MISMATCH = new ErrorReason(
+                "jwk-kid-mismatch",
+                "Unable to find a signing key in JWKS that matches the kid of the provided session token."
+            ),
+            TOKEN_EXPIRED = new ErrorReason(
+                "token-expired",
+                "Token has expired and is no longer valid."
+            ),
+            TOKEN_INVALID = new ErrorReason(
+                "token-invalid",
+                "Token is invalid and could not be verified."
+            ),
+            TOKEN_INVALID_AUTHORIZED_PARTIES = new ErrorReason(
+                "token-invalid-authorized-parties",
+                "Authorized party claim (azp) does not match any of the authorized parties."
+            ),
+            TOKEN_INVALID_AUDIENCE = new ErrorReason(
+                "token-invalid-audience",
+                "Token audience claim (aud) does not match one of the expected audience values."
+            ),
+            TOKEN_IAT_IN_THE_FUTURE = new ErrorReason(
+                "token-iat-in-the-future",
+                "Token Issued At claim (iat) represents a time in the future."
+            ),
+            TOKEN_NOT_ACTIVE_YET = new ErrorReason(
+                "token-not-active-yet",
+                "Token is not yet valid. Not Before claim (nbf) is in the future."
+            ),
+            TOKEN_INVALID_SIGNATURE = new ErrorReason(
+                "token-invalid-signature",
+                "Token signature is invalid and could not be verified."
+            ),
+            SECRET_KEY_MISSING = new ErrorReason(
+                "secret-key-missing",
+                "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
+            );
+    }
+}

--- a/src/Clerk/BackendAPI/Helpers/TokenVerificationException.cs
+++ b/src/Clerk/BackendAPI/Helpers/TokenVerificationException.cs
@@ -1,86 +1,80 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+public class TokenVerificationException : Exception
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
+    public readonly ErrorReason Reason;
 
-    public class TokenVerificationException : Exception
+    public TokenVerificationException(ErrorReason reason) : base(reason.Message)
     {
-        public readonly ErrorReason Reason;
-
-        public TokenVerificationException(ErrorReason reason) : base(reason.Message)
-        {
-            this.Reason = reason;
-        }
-
-        public TokenVerificationException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
-        {
-            this.Reason = reason;
-        }
-
-        public override string ToString()
-        {
-            return this.Reason.Message;
-        }
+        Reason = reason;
     }
 
-    public static class TokenVerificationErrorReason
+    public TokenVerificationException(ErrorReason reason, Exception cause) : base(reason.Message, cause)
     {
-        public static readonly ErrorReason
-            JWK_FAILED_TO_LOAD = new ErrorReason(
-                "jwk-failed-to-load",
-                "Failed to load JWKS from Clerk Backend API. Contact support@clerk.com."
-            ),
-            JWK_REMOTE_INVALID = new ErrorReason(
-                "jwk-remote-invalid",
-                "The JWKS endpoint did not contain any signing keys. Contact support@clerk.com."
-            ),
-            JWK_LOCAL_INVALID = new ErrorReason(
-                "jwk-local-invalid",
-                "The provided PEM Public Key is not in the proper format."
-            ),
-            JWK_FAILED_TO_RESOLVE = new ErrorReason(
-                "jwk-failed-to-resolve",
-                "Failed to resolve JWK. Public Key is not in the proper format."
-            ),
-            JWK_KID_MISMATCH = new ErrorReason(
-                "jwk-kid-mismatch",
-                "Unable to find a signing key in JWKS that matches the kid of the provided session token."
-            ),
-            TOKEN_EXPIRED = new ErrorReason(
-                "token-expired",
-                "Token has expired and is no longer valid."
-            ),
-            TOKEN_INVALID = new ErrorReason(
-                "token-invalid",
-                "Token is invalid and could not be verified."
-            ),
-            TOKEN_INVALID_AUTHORIZED_PARTIES = new ErrorReason(
-                "token-invalid-authorized-parties",
-                "Authorized party claim (azp) does not match any of the authorized parties."
-            ),
-            TOKEN_INVALID_AUDIENCE = new ErrorReason(
-                "token-invalid-audience",
-                "Token audience claim (aud) does not match one of the expected audience values."
-            ),
-            TOKEN_IAT_IN_THE_FUTURE = new ErrorReason(
-                "token-iat-in-the-future",
-                "Token Issued At claim (iat) represents a time in the future."
-            ),
-            TOKEN_NOT_ACTIVE_YET = new ErrorReason(
-                "token-not-active-yet",
-                "Token is not yet valid. Not Before claim (nbf) is in the future."
-            ),
-            TOKEN_INVALID_SIGNATURE = new ErrorReason(
-                "token-invalid-signature",
-                "Token signature is invalid and could not be verified."
-            ),
-            SECRET_KEY_MISSING = new ErrorReason(
-                "secret-key-missing",
-                "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
-            );
+        Reason = reason;
     }
+
+    public override string ToString()
+    {
+        return Reason.Message;
+    }
+}
+
+public static class TokenVerificationErrorReason
+{
+    public static readonly ErrorReason
+        JWK_FAILED_TO_LOAD = new(
+            "jwk-failed-to-load",
+            "Failed to load JWKS from Clerk Backend API. Contact support@clerk.com."
+        ),
+        JWK_REMOTE_INVALID = new(
+            "jwk-remote-invalid",
+            "The JWKS endpoint did not contain any signing keys. Contact support@clerk.com."
+        ),
+        JWK_LOCAL_INVALID = new(
+            "jwk-local-invalid",
+            "The provided PEM Public Key is not in the proper format."
+        ),
+        JWK_FAILED_TO_RESOLVE = new(
+            "jwk-failed-to-resolve",
+            "Failed to resolve JWK. Public Key is not in the proper format."
+        ),
+        JWK_KID_MISMATCH = new(
+            "jwk-kid-mismatch",
+            "Unable to find a signing key in JWKS that matches the kid of the provided session token."
+        ),
+        TOKEN_EXPIRED = new(
+            "token-expired",
+            "Token has expired and is no longer valid."
+        ),
+        TOKEN_INVALID = new(
+            "token-invalid",
+            "Token is invalid and could not be verified."
+        ),
+        TOKEN_INVALID_AUTHORIZED_PARTIES = new(
+            "token-invalid-authorized-parties",
+            "Authorized party claim (azp) does not match any of the authorized parties."
+        ),
+        TOKEN_INVALID_AUDIENCE = new(
+            "token-invalid-audience",
+            "Token audience claim (aud) does not match one of the expected audience values."
+        ),
+        TOKEN_IAT_IN_THE_FUTURE = new(
+            "token-iat-in-the-future",
+            "Token Issued At claim (iat) represents a time in the future."
+        ),
+        TOKEN_NOT_ACTIVE_YET = new(
+            "token-not-active-yet",
+            "Token is not yet valid. Not Before claim (nbf) is in the future."
+        ),
+        TOKEN_INVALID_SIGNATURE = new(
+            "token-invalid-signature",
+            "Token signature is invalid and could not be verified."
+        ),
+        SECRET_KEY_MISSING = new(
+            "secret-key-missing",
+            "Missing Clerk Secret Key. Go to https://dashboard.clerk.com and get your key for your instance."
+        );
 }

--- a/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
+++ b/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
@@ -1,260 +1,226 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Clerk.BackendAPI.Models.Components;
+using Clerk.BackendAPI.Utils;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+public static class VerifyToken
 {
-    using Microsoft.IdentityModel.Tokens;
-    using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json;
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.IdentityModel.Tokens.Jwt;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Reflection;
-    using System.Security.Claims;
-    using System.Security.Cryptography;
-    using System.Security.Cryptography.X509Certificates;
-    using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using Clerk.BackendAPI.Models.Components;
-    using Clerk.BackendAPI.Utils;
-
-    public static class VerifyToken
+    public static async Task<ClaimsPrincipal> VerifyTokenAsync(string token, VerifyTokenOptions options)
     {
-        public static async Task<ClaimsPrincipal> VerifyTokenAsync(string token, VerifyTokenOptions options)
+        RsaSecurityKey rsaKey;
+        if (options.JwtKey != null)
+            rsaKey = GetLocalJwtKey(options.JwtKey);
+        else
+            rsaKey = await GetRemoteJwtKeyAsync(token, options);
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+
+        var validationParameters = new TokenValidationParameters
         {
-            RsaSecurityKey rsaKey;
-            if (options.JwtKey != null)
+            ValidateIssuer = false,
+            ValidateAudience = options.Audiences != null,
+            ValidAudiences = options.Audiences,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = rsaKey,
+            ClockSkew = TimeSpan.FromMilliseconds(options.ClockSkewInMs)
+        };
+
+        ClaimsPrincipal claims;
+        try
+        {
+            claims = tokenHandler.ValidateToken(token, validationParameters, out var validatedToken);
+        }
+        catch (SecurityTokenExpiredException ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_EXPIRED, ex);
+        }
+        catch (SecurityTokenNotYetValidException ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_NOT_ACTIVE_YET, ex);
+        }
+        catch (SecurityTokenInvalidSignatureException ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_SIGNATURE, ex);
+        }
+        catch (SecurityTokenInvalidAudienceException ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUDIENCE, ex);
+        }
+        catch (Exception ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID, ex);
+        }
+
+        if (options.AuthorizedParties != null)
+        {
+            var azpClaim = claims.FindFirst("azp");
+            if (azpClaim != null && !options.AuthorizedParties.Contains(azpClaim.Value))
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUTHORIZED_PARTIES);
+        }
+
+        var iatClaim = claims.FindFirst("iat");
+        if (iatClaim != null && long.Parse(iatClaim.Value) >
+            DateTimeOffset.UtcNow.ToUnixTimeSeconds() + options.ClockSkewInMs / 1000)
+            throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_IAT_IN_THE_FUTURE);
+
+
+        return claims;
+    }
+
+    /// <summary>
+    ///     Converts a RSA PEM formatted public key to a RsaSecurityKey object
+    ///     that can be used for networkless verification.
+    /// </summary>
+    /// <param name="jwtKey">The PEM formatted public key.</param>
+    /// <returns>The RSA public key</returns>
+    /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
+    private static RsaSecurityKey GetLocalJwtKey(string jwtKey)
+    {
+        try
+        {
+            var rsa = RSA.Create();
+            rsa.ImportFromPem(jwtKey.ToCharArray());
+            return new RsaSecurityKey(rsa);
+        }
+        catch (Exception ex)
+        {
+            throw new TokenVerificationException(TokenVerificationErrorReason.JWK_LOCAL_INVALID, ex);
+        }
+    }
+
+    /// <summary>
+    ///     Retrieves the RSA public key used to sign the token from Clerk's Backend API.
+    /// </summary>
+    /// <param name="token">The token to parse.</param>
+    /// <param name="options">The options used for token verification.</param>
+    /// <returns>The RSA public key.</returns>
+    /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
+    private static async Task<RsaSecurityKey> GetRemoteJwtKeyAsync(string token, VerifyTokenOptions options)
+    {
+        var kid = ParseKid(token);
+
+        var jwks = await FetchJwksAsync(options);
+        if (jwks.Keys == null) throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
+
+        foreach (var key in jwks.Keys)
+            if (key.Kid == kid)
             {
-                rsaKey = GetLocalJwtKey(options.JwtKey);
+                if ((key.N == null) | (key.E == null))
+                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
+                try
+                {
+                    var rsaParameters = new RSAParameters
+                    {
+                        Modulus = Base64UrlDecode(key.N!),
+                        Exponent = Base64UrlDecode(key.E!)
+                    };
+                    var rsa = RSA.Create();
+                    rsa.ImportParameters(rsaParameters);
+
+                    return new RsaSecurityKey(rsa);
+                }
+                catch (Exception ex)
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_RESOLVE, ex);
+                }
             }
-            else
-            {
-                rsaKey = await GetRemoteJwtKeyAsync(token, options);
-            }
 
-            var tokenHandler = new JwtSecurityTokenHandler();
+        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
+    }
 
-            var validationParameters = new TokenValidationParameters
-            {
-                ValidateIssuer = false,
-                ValidateAudience = options.Audiences != null,
-                ValidAudiences = options.Audiences,
-                ValidateLifetime = true,
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = rsaKey,
-                ClockSkew = TimeSpan.FromMilliseconds(options.ClockSkewInMs)
-            };
 
-            ClaimsPrincipal claims;
+    /// <summary>
+    ///     Decodes a base64url encoded string.
+    /// </summary>
+    /// <param name="input">The base64url encoded string.</param>
+    /// <returns>The decoded byte array.</returns>
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var base64 = input.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+
+        return Convert.FromBase64String(base64);
+    }
+
+    /// <summary>
+    ///     Retrieves the key identifier (kid) from the token header.
+    /// </summary>
+    /// <param name="token">The token to parse.</param>
+    /// <returns>The key identifier (kid).</returns>
+    /// <exception cref="TokenVerificationException">if the kid cannot be parsed.</exception>
+    private static string ParseKid(string token)
+    {
+        var handler = new JwtSecurityTokenHandler();
+
+        if (handler.CanReadToken(token))
             try
             {
-                claims = tokenHandler.ValidateToken(token, validationParameters, out SecurityToken validatedToken);
-            }
-            catch (SecurityTokenExpiredException ex)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_EXPIRED, ex);
-            }
-            catch (SecurityTokenNotYetValidException ex)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_NOT_ACTIVE_YET, ex);
-            }
-            catch (SecurityTokenInvalidSignatureException ex)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_SIGNATURE, ex);
-            }
-            catch (SecurityTokenInvalidAudienceException ex)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUDIENCE, ex);
+                var jwtToken = handler.ReadJwtToken(token);
+
+                if (jwtToken.Header.TryGetValue("kid", out var kid))
+                    if (kid != null)
+                        return (string)kid;
             }
             catch (Exception ex)
             {
                 throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID, ex);
             }
 
-            if (options.AuthorizedParties != null)
-            {
-                var azpClaim = claims.FindFirst("azp");
-                if (azpClaim != null && !options.AuthorizedParties.Contains(azpClaim.Value))
-                {
-                    throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUTHORIZED_PARTIES);
-                }
-            }
+        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
+    }
 
-            var iatClaim = claims.FindFirst("iat");
-            if (iatClaim != null && long.Parse(iatClaim.Value) > DateTimeOffset.UtcNow.ToUnixTimeSeconds() + options.ClockSkewInMs / 1000)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_IAT_IN_THE_FUTURE);
-            }
+    /// <summary>
+    ///     Fetches the JSON Web Key Set (JWKS) from Clerk's Backend API.
+    /// </summary>
+    /// <param name="options">The options used for token verification.</param>
+    /// <returns>The JWKS keys array as a JSON node.</returns>
+    /// <exception cref="TokenVerificationException">if the JWKS cannot be fetched.</exception>
+    private static async Task<WellKnownJWKS> FetchJwksAsync(VerifyTokenOptions options)
+    {
+        if (options.SecretKey == null)
+            throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
 
-
-            return claims;
-        }
-
-        /// <summary>
-        /// Converts a RSA PEM formatted public key to a RsaSecurityKey object
-        /// that can be used for networkless verification.
-        /// </summary>
-        /// <param name="jwtKey">The PEM formatted public key.</param>
-        /// <returns>The RSA public key</returns>
-        /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
-        private static RsaSecurityKey GetLocalJwtKey(string jwtKey)
+        using (var client = new HttpClient())
         {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.SecretKey);
+            var jwksUrl = $"{options.ApiUrl}/{options.ApiVersion}/jwks";
+
+
+            var httpResponse = await client.GetAsync(jwksUrl);
+            if (!httpResponse.IsSuccessStatusCode)
+                throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD);
+
+            var responseBody = await httpResponse.Content.ReadAsStringAsync();
+
+            WellKnownJWKS? wellKnownJWKS;
             try
             {
-                RSA rsa = RSA.Create();
-                rsa.ImportFromPem(jwtKey.ToCharArray());
-                return new RsaSecurityKey(rsa);
+                wellKnownJWKS = ResponseBodyDeserializer.Deserialize<WellKnownJWKS>(responseBody);
             }
-            catch (Exception ex)
+            catch (JsonReaderException ex)
             {
-                throw new TokenVerificationException(TokenVerificationErrorReason.JWK_LOCAL_INVALID, ex);
+                throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD, ex);
             }
-        }
 
-        /// <summary>
-        /// Retrieves the RSA public key used to sign the token from Clerk's Backend API.
-        /// </summary>
-        /// <param name="token">The token to parse.</param>
-        /// <param name="options">The options used for token verification.</param>
-        /// <returns>The RSA public key.</returns>
-        /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
-        private static async Task<RsaSecurityKey> GetRemoteJwtKeyAsync(string token, VerifyTokenOptions options)
-        {
-            string kid = ParseKid(token);
-
-            WellKnownJWKS jwks = await FetchJwksAsync(options);
-            if (jwks.Keys == null)
-            {
+            if (wellKnownJWKS == null)
                 throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
-            }
 
-            foreach (var key in jwks.Keys)
-            {
-                if (key.Kid == kid)
-                {
-                    if (key.N == null | key.E == null)
-                    {
-                        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
-                    }
-                    try
-                    {
-                        RSAParameters rsaParameters = new RSAParameters
-                        {
-                            Modulus = Base64UrlDecode(key.N!),
-                            Exponent = Base64UrlDecode(key.E!)
-                        };
-                        RSA rsa = RSA.Create();
-                        rsa.ImportParameters(rsaParameters);
-
-                        return new RsaSecurityKey(rsa);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_RESOLVE, ex);
-                    }
-                }
-            }
-
-            throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
-        }
-
-
-        /// <summary>
-        /// Decodes a base64url encoded string.
-        /// </summary>
-        /// <param name="input">The base64url encoded string.</param>
-        /// <returns>The decoded byte array.</returns>
-        private static byte[] Base64UrlDecode(string input)
-        {
-            string base64 = input.Replace('-', '+').Replace('_', '/');
-            switch (base64.Length % 4)
-            {
-                case 2: base64 += "=="; break;
-                case 3: base64 += "="; break;
-            }
-            return Convert.FromBase64String(base64);
-        }
-
-        /// <summary>
-        /// Retrieves the key identifier (kid) from the token header.
-        /// </summary>
-        /// <param name="token">The token to parse.</param>
-        /// <returns>The key identifier (kid).</returns>
-        /// <exception cref="TokenVerificationException">if the kid cannot be parsed.</exception>
-        private static string ParseKid(string token)
-        {
-            var handler = new JwtSecurityTokenHandler();
-
-            if (handler.CanReadToken(token))
-            {
-                try
-                {
-                    var jwtToken = handler.ReadJwtToken(token);
-
-                    if (jwtToken.Header.TryGetValue("kid", out var kid))
-                    {
-                        if (kid != null)
-                        {
-                            return (string)kid;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID, ex);
-                }
-            }
-
-            throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
-        }
-
-        /// <summary>
-        /// Fetches the JSON Web Key Set (JWKS) from Clerk's Backend API.
-        /// </summary>
-        /// <param name="options">The options used for token verification.</param>
-        /// <returns>The JWKS keys array as a JSON node.</returns>
-        /// <exception cref="TokenVerificationException">if the JWKS cannot be fetched.</exception>
-        private static async Task<WellKnownJWKS> FetchJwksAsync(VerifyTokenOptions options)
-        {
-            if (options.SecretKey == null)
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
-            }
-
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.SecretKey);
-                var jwksUrl = $"{options.ApiUrl}/{options.ApiVersion}/jwks";
-
-
-                var httpResponse = await client.GetAsync(jwksUrl);
-                if (!httpResponse.IsSuccessStatusCode)
-                {
-                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD);
-                }
-
-                var responseBody = await httpResponse.Content.ReadAsStringAsync();
-
-                WellKnownJWKS? wellKnownJWKS;
-                try
-                {
-                    wellKnownJWKS = ResponseBodyDeserializer.Deserialize<WellKnownJWKS>(responseBody);
-                }
-                catch (JsonReaderException ex)
-                {
-                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD, ex);
-                }
-
-                if (wellKnownJWKS == null)
-                {
-                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
-                }
-
-                return wellKnownJWKS!;
-            }
+            return wellKnownJWKS!;
         }
     }
 }

--- a/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
+++ b/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
@@ -1,0 +1,260 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using Microsoft.IdentityModel.Tokens;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Security.Claims;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using Clerk.BackendAPI.Models.Components;
+    using Clerk.BackendAPI.Utils;
+
+    public static class VerifyToken
+    {
+        public static async Task<ClaimsPrincipal> VerifyTokenAsync(string token, VerifyTokenOptions options)
+        {
+            RsaSecurityKey rsaKey;
+            if (options.JwtKey != null)
+            {
+                rsaKey = GetLocalJwtKey(options.JwtKey);
+            }
+            else
+            {
+                rsaKey = await GetRemoteJwtKeyAsync(token, options);
+            }
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = options.Audiences != null,
+                ValidAudiences = options.Audiences,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = rsaKey,
+                ClockSkew = TimeSpan.FromMilliseconds(options.ClockSkewInMs)
+            };
+
+            ClaimsPrincipal claims;
+            try
+            {
+                claims = tokenHandler.ValidateToken(token, validationParameters, out SecurityToken validatedToken);
+            }
+            catch (SecurityTokenExpiredException ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_EXPIRED, ex);
+            }
+            catch (SecurityTokenNotYetValidException ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_NOT_ACTIVE_YET, ex);
+            }
+            catch (SecurityTokenInvalidSignatureException ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_SIGNATURE, ex);
+            }
+            catch (SecurityTokenInvalidAudienceException ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUDIENCE, ex);
+            }
+            catch (Exception ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID, ex);
+            }
+
+            if (options.AuthorizedParties != null)
+            {
+                var azpClaim = claims.FindFirst("azp");
+                if (azpClaim != null && !options.AuthorizedParties.Contains(azpClaim.Value))
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID_AUTHORIZED_PARTIES);
+                }
+            }
+
+            var iatClaim = claims.FindFirst("iat");
+            if (iatClaim != null && long.Parse(iatClaim.Value) > DateTimeOffset.UtcNow.ToUnixTimeSeconds() + options.ClockSkewInMs / 1000)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_IAT_IN_THE_FUTURE);
+            }
+
+
+            return claims;
+        }
+
+        /// <summary>
+        /// Converts a RSA PEM formatted public key to a RsaSecurityKey object
+        /// that can be used for networkless verification.
+        /// </summary>
+        /// <param name="jwtKey">The PEM formatted public key.</param>
+        /// <returns>The RSA public key</returns>
+        /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
+        private static RsaSecurityKey GetLocalJwtKey(string jwtKey)
+        {
+            try
+            {
+                RSA rsa = RSA.Create();
+                rsa.ImportFromPem(jwtKey.ToCharArray());
+                return new RsaSecurityKey(rsa);
+            }
+            catch (Exception ex)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.JWK_LOCAL_INVALID, ex);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the RSA public key used to sign the token from Clerk's Backend API.
+        /// </summary>
+        /// <param name="token">The token to parse.</param>
+        /// <param name="options">The options used for token verification.</param>
+        /// <returns>The RSA public key.</returns>
+        /// <exception cref="TokenVerificationException">if the public key could not be resolved.</exception>
+        private static async Task<RsaSecurityKey> GetRemoteJwtKeyAsync(string token, VerifyTokenOptions options)
+        {
+            string kid = ParseKid(token);
+
+            WellKnownJWKS jwks = await FetchJwksAsync(options);
+            if (jwks.Keys == null)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
+            }
+
+            foreach (var key in jwks.Keys)
+            {
+                if (key.Kid == kid)
+                {
+                    if (key.N == null | key.E == null)
+                    {
+                        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
+                    }
+                    try
+                    {
+                        RSAParameters rsaParameters = new RSAParameters
+                        {
+                            Modulus = Base64UrlDecode(key.N!),
+                            Exponent = Base64UrlDecode(key.E!)
+                        };
+                        RSA rsa = RSA.Create();
+                        rsa.ImportParameters(rsaParameters);
+
+                        return new RsaSecurityKey(rsa);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_RESOLVE, ex);
+                    }
+                }
+            }
+
+            throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
+        }
+
+
+        /// <summary>
+        /// Decodes a base64url encoded string.
+        /// </summary>
+        /// <param name="input">The base64url encoded string.</param>
+        /// <returns>The decoded byte array.</returns>
+        private static byte[] Base64UrlDecode(string input)
+        {
+            string base64 = input.Replace('-', '+').Replace('_', '/');
+            switch (base64.Length % 4)
+            {
+                case 2: base64 += "=="; break;
+                case 3: base64 += "="; break;
+            }
+            return Convert.FromBase64String(base64);
+        }
+
+        /// <summary>
+        /// Retrieves the key identifier (kid) from the token header.
+        /// </summary>
+        /// <param name="token">The token to parse.</param>
+        /// <returns>The key identifier (kid).</returns>
+        /// <exception cref="TokenVerificationException">if the kid cannot be parsed.</exception>
+        private static string ParseKid(string token)
+        {
+            var handler = new JwtSecurityTokenHandler();
+
+            if (handler.CanReadToken(token))
+            {
+                try
+                {
+                    var jwtToken = handler.ReadJwtToken(token);
+
+                    if (jwtToken.Header.TryGetValue("kid", out var kid))
+                    {
+                        if (kid != null)
+                        {
+                            return (string)kid;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.TOKEN_INVALID, ex);
+                }
+            }
+
+            throw new TokenVerificationException(TokenVerificationErrorReason.JWK_KID_MISMATCH);
+        }
+
+        /// <summary>
+        /// Fetches the JSON Web Key Set (JWKS) from Clerk's Backend API.
+        /// </summary>
+        /// <param name="options">The options used for token verification.</param>
+        /// <returns>The JWKS keys array as a JSON node.</returns>
+        /// <exception cref="TokenVerificationException">if the JWKS cannot be fetched.</exception>
+        private static async Task<WellKnownJWKS> FetchJwksAsync(VerifyTokenOptions options)
+        {
+            if (options.SecretKey == null)
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
+            }
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.SecretKey);
+                var jwksUrl = $"{options.ApiUrl}/{options.ApiVersion}/jwks";
+
+
+                var httpResponse = await client.GetAsync(jwksUrl);
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD);
+                }
+
+                var responseBody = await httpResponse.Content.ReadAsStringAsync();
+
+                WellKnownJWKS? wellKnownJWKS;
+                try
+                {
+                    wellKnownJWKS = ResponseBodyDeserializer.Deserialize<WellKnownJWKS>(responseBody);
+                }
+                catch (JsonReaderException ex)
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD, ex);
+                }
+
+                if (wellKnownJWKS == null)
+                {
+                    throw new TokenVerificationException(TokenVerificationErrorReason.JWK_REMOTE_INVALID);
+                }
+
+                return wellKnownJWKS!;
+            }
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Helpers/VerifyTokenOptions.cs
+++ b/src/Clerk/BackendAPI/Helpers/VerifyTokenOptions.cs
@@ -1,0 +1,59 @@
+#nullable enable
+namespace Clerk.BackendAPI.Helpers.Jwks
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+
+    public sealed class VerifyTokenOptions
+    {
+        private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
+        private static readonly string DEFAULT_API_URL = "https://api.clerk.com";
+        private static readonly string DEFAULT_API_VERSION = "v1";
+
+        public readonly string? SecretKey;
+        public readonly string? JwtKey;
+        public readonly IEnumerable<string>? Audiences;
+        public readonly IEnumerable<string>? AuthorizedParties;
+        public readonly long ClockSkewInMs;
+        public readonly string ApiUrl;
+        public readonly string ApiVersion;
+
+        /// <summary>
+        /// Options to configure VerifyToken.
+        /// </summary>
+        /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
+        /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
+        /// <param name="audiences">A list of audiences to verify against.</param>
+        /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
+        /// <param name="clockSkewInMs">Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.</param>
+        /// <param name="apiUrl">The Clerk Backend API endpoint. Defaults to 'https://api.clerk.com'</param>
+        /// <param name="apiVersion">The version passed to the Clerk API. Defaults to 'v1'</param>
+        public VerifyTokenOptions(
+            string? secretKey = null,
+            string? jwtKey = null,
+            IEnumerable<string>? audiences = null,
+            IEnumerable<string>? authorizedParties = null,
+            long? clockSkewInMs = null,
+            string? apiUrl = null,
+            string? apiVersion = null)
+        {
+
+            if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
+            {
+                throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
+            }
+
+            SecretKey = secretKey;
+            JwtKey = jwtKey;
+            Audiences = audiences;
+            AuthorizedParties = authorizedParties;
+            ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
+            ApiUrl = apiUrl ?? DEFAULT_API_URL;
+            ApiVersion = apiVersion ?? DEFAULT_API_VERSION;
+        }
+    }
+
+}

--- a/src/Clerk/BackendAPI/Helpers/VerifyTokenOptions.cs
+++ b/src/Clerk/BackendAPI/Helpers/VerifyTokenOptions.cs
@@ -1,59 +1,52 @@
-#nullable enable
-namespace Clerk.BackendAPI.Helpers.Jwks
+using System.Collections.Generic;
+
+namespace Clerk.BackendAPI.Helpers.Jwks;
+
+public sealed class VerifyTokenOptions
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
+    private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
+    private static readonly string DEFAULT_API_URL = "https://api.clerk.com";
+    private static readonly string DEFAULT_API_VERSION = "v1";
+    public readonly string ApiUrl;
+    public readonly string ApiVersion;
+    public readonly IEnumerable<string>? Audiences;
+    public readonly IEnumerable<string>? AuthorizedParties;
+    public readonly long ClockSkewInMs;
+    public readonly string? JwtKey;
 
-    public sealed class VerifyTokenOptions
+    public readonly string? SecretKey;
+
+    /// <summary>
+    ///     Options to configure VerifyTokenAsync.
+    /// </summary>
+    /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
+    /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
+    /// <param name="audiences">A list of audiences to verify against.</param>
+    /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
+    /// <param name="clockSkewInMs">
+    ///     Allowed time difference (in milliseconds) between the Clerk server (which generates the
+    ///     token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.
+    /// </param>
+    /// <param name="apiUrl">The Clerk Backend API endpoint. Defaults to 'https://api.clerk.com'</param>
+    /// <param name="apiVersion">The version passed to the Clerk API. Defaults to 'v1'</param>
+    public VerifyTokenOptions(
+        string? secretKey = null,
+        string? jwtKey = null,
+        IEnumerable<string>? audiences = null,
+        IEnumerable<string>? authorizedParties = null,
+        long? clockSkewInMs = null,
+        string? apiUrl = null,
+        string? apiVersion = null)
     {
-        private static readonly long DEFAULT_CLOCK_SKEW_MS = 5000L;
-        private static readonly string DEFAULT_API_URL = "https://api.clerk.com";
-        private static readonly string DEFAULT_API_VERSION = "v1";
+        if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
+            throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
 
-        public readonly string? SecretKey;
-        public readonly string? JwtKey;
-        public readonly IEnumerable<string>? Audiences;
-        public readonly IEnumerable<string>? AuthorizedParties;
-        public readonly long ClockSkewInMs;
-        public readonly string ApiUrl;
-        public readonly string ApiVersion;
-
-        /// <summary>
-        /// Options to configure VerifyToken.
-        /// </summary>
-        /// <param name="secretKey">The Clerk secret key from the API Keys page in the Clerk Dashboard. (Optional)</param>
-        /// <param name="jwtKey">PEM Public String used to verify the session token in a networkless manner. (Optional)</param>
-        /// <param name="audiences">A list of audiences to verify against.</param>
-        /// <param name="authorizedParties">An allowlist of origins to verify against.</param>
-        /// <param name="clockSkewInMs">Allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms.</param>
-        /// <param name="apiUrl">The Clerk Backend API endpoint. Defaults to 'https://api.clerk.com'</param>
-        /// <param name="apiVersion">The version passed to the Clerk API. Defaults to 'v1'</param>
-        public VerifyTokenOptions(
-            string? secretKey = null,
-            string? jwtKey = null,
-            IEnumerable<string>? audiences = null,
-            IEnumerable<string>? authorizedParties = null,
-            long? clockSkewInMs = null,
-            string? apiUrl = null,
-            string? apiVersion = null)
-        {
-
-            if (string.IsNullOrEmpty(secretKey) && string.IsNullOrEmpty(jwtKey))
-            {
-                throw new TokenVerificationException(TokenVerificationErrorReason.SECRET_KEY_MISSING);
-            }
-
-            SecretKey = secretKey;
-            JwtKey = jwtKey;
-            Audiences = audiences;
-            AuthorizedParties = authorizedParties;
-            ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
-            ApiUrl = apiUrl ?? DEFAULT_API_URL;
-            ApiVersion = apiVersion ?? DEFAULT_API_VERSION;
-        }
+        SecretKey = secretKey;
+        JwtKey = jwtKey;
+        Audiences = audiences;
+        AuthorizedParties = authorizedParties;
+        ClockSkewInMs = clockSkewInMs ?? DEFAULT_CLOCK_SKEW_MS;
+        ApiUrl = apiUrl ?? DEFAULT_API_URL;
+        ApiVersion = apiVersion ?? DEFAULT_API_VERSION;
     }
-
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+obj/
+bin/
+debug/

--- a/tests/JwksHelpers/AuthenticateRequestTests.cs
+++ b/tests/JwksHelpers/AuthenticateRequestTests.cs
@@ -1,0 +1,103 @@
+#nullable enable
+namespace JwksHelpers.Tests
+{
+    using Clerk.BackendAPI.Helpers.Jwks;
+    using Microsoft.IdentityModel.Tokens;
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Net.Http;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+    using System.Text;
+    using Xunit;
+
+    public class AuthenticateRequestTests : IClassFixture<JwksHelpersFixture>
+    {
+        private readonly JwksHelpersFixture _fixture;
+        private readonly Uri _requestUri;
+
+        public AuthenticateRequestTests(JwksHelpersFixture fixture)
+        {
+            _fixture = fixture;
+            _requestUri = new Uri(_fixture.RequestUrl);
+        }
+
+        [Fact]
+        public async Task TestAuthenticateRequestNoSesstionToken ()
+        {
+            var arOptions = new AuthenticateRequestOptions(secretKey: "sk_test_SecretKey");
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, _requestUri);
+            var state = await AuthenticateRequest.AuthenticateRequestAsync(request, arOptions);
+
+                Assert.True(state.IsSignedOut());
+                Assert.Equal(AuthErrorReason.SESSION_TOKEN_MISSING, state.ErrorReason);
+                Assert.Null(state.Token);
+                Assert.Null(state.Claims);
+        }
+
+        [Fact]
+        public void TestAuthenticateRequestNoSecretKey ()
+        {
+            var ex = Assert.Throws<AuthenticateRequestException>(
+                () => new AuthenticateRequestOptions()
+            );
+
+            Assert.Equal(AuthErrorReason.SECRET_KEY_MISSING, ex.Reason);
+            Assert.Null(ex.InnerException);
+            Assert.Contains("Missing Clerk Secret Key.", ex.Message);
+        }
+
+        [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
+        public async Task TestAuthenticateRequestCookie ()
+        {
+            var arOptions = new AuthenticateRequestOptions(
+                secretKey: _fixture.SecretKey,
+                audiences: _fixture.Audiences,
+                authorizedParties: _fixture.AuthorizedParties
+            );
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, _requestUri);
+            request.Headers.Add("Cookie", $"__session={_fixture.SessionToken}");
+
+            var state = await AuthenticateRequest.AuthenticateRequestAsync(request, arOptions);
+
+            Utils.AssertStateAsync(state, _fixture.SessionToken);
+        }
+
+        [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
+        public async Task TestAuthenticateRequestBearer ()
+        {
+            var arOptions = new AuthenticateRequestOptions(
+                secretKey: _fixture.SecretKey,
+                audiences: _fixture.Audiences,
+                authorizedParties: _fixture.AuthorizedParties
+            );
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, _requestUri);
+            request.Headers.Add("Authorization", $"Bearer {_fixture.SessionToken}");
+
+            var state = await AuthenticateRequest.AuthenticateRequestAsync(request, arOptions);
+
+            Utils.AssertStateAsync(state, _fixture.SessionToken);
+        }
+
+        [ConditionalFact("CLERK_JWT_KEY", "CLERK_SESSION_TOKEN")]
+        public async Task TestAuthenticateRequestLocal ()
+        {
+            var arOptions = new AuthenticateRequestOptions(
+                jwtKey: _fixture.JwtKey,
+                audiences: _fixture.Audiences,
+                authorizedParties: _fixture.AuthorizedParties
+            );
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, _requestUri);
+            request.Headers.Add("Authorization", $"Bearer {_fixture.SessionToken}");
+
+            var state = await AuthenticateRequest.AuthenticateRequestAsync(request, arOptions);
+
+            Utils.AssertStateAsync(state, _fixture.SessionToken);
+        }
+    }
+}

--- a/tests/JwksHelpers/AuthenticateRequestTests.cs
+++ b/tests/JwksHelpers/AuthenticateRequestTests.cs
@@ -24,21 +24,21 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestAuthenticateRequestNoSesstionToken ()
+        public async Task TestAuthenticateRequestNoSesstionToken()
         {
             var arOptions = new AuthenticateRequestOptions(secretKey: "sk_test_SecretKey");
 
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, _requestUri);
             var state = await AuthenticateRequest.AuthenticateRequestAsync(request, arOptions);
 
-                Assert.True(state.IsSignedOut());
-                Assert.Equal(AuthErrorReason.SESSION_TOKEN_MISSING, state.ErrorReason);
-                Assert.Null(state.Token);
-                Assert.Null(state.Claims);
+            Assert.True(state.IsSignedOut());
+            Assert.Equal(AuthErrorReason.SESSION_TOKEN_MISSING, state.ErrorReason);
+            Assert.Null(state.Token);
+            Assert.Null(state.Claims);
         }
 
         [Fact]
-        public void TestAuthenticateRequestNoSecretKey ()
+        public void TestAuthenticateRequestNoSecretKey()
         {
             var ex = Assert.Throws<AuthenticateRequestException>(
                 () => new AuthenticateRequestOptions()
@@ -50,7 +50,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
-        public async Task TestAuthenticateRequestCookie ()
+        public async Task TestAuthenticateRequestCookie()
         {
             var arOptions = new AuthenticateRequestOptions(
                 secretKey: _fixture.SecretKey,
@@ -67,7 +67,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
-        public async Task TestAuthenticateRequestBearer ()
+        public async Task TestAuthenticateRequestBearer()
         {
             var arOptions = new AuthenticateRequestOptions(
                 secretKey: _fixture.SecretKey,
@@ -84,7 +84,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_JWT_KEY", "CLERK_SESSION_TOKEN")]
-        public async Task TestAuthenticateRequestLocal ()
+        public async Task TestAuthenticateRequestLocal()
         {
             var arOptions = new AuthenticateRequestOptions(
                 jwtKey: _fixture.JwtKey,

--- a/tests/JwksHelpers/Utils.cs
+++ b/tests/JwksHelpers/Utils.cs
@@ -1,0 +1,171 @@
+#nullable enable
+namespace JwksHelpers.Tests
+{
+    using Clerk.BackendAPI.Helpers.Jwks;
+    using Microsoft.IdentityModel.Tokens;
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class JwksHelpersFixture
+    {
+        public readonly string RequestUrl = "http://localhost:3000";
+
+        public readonly string? SecretKey;
+        public readonly string? JwtKey;
+        public readonly string SessionToken;
+        public readonly string? ApiUrl;
+        public readonly List<string>? Audiences;
+        public readonly List<string> AuthorizedParties;
+
+        public readonly string TestToken;
+        public readonly string TestJwtKey;
+
+        public JwksHelpersFixture()
+        {
+            SecretKey = System.Environment.GetEnvironmentVariable("CLERK_SECRET_KEY");
+            JwtKey = System.Environment.GetEnvironmentVariable("CLERK_JWT_KEY");
+            ApiUrl = System.Environment.GetEnvironmentVariable("CLERK_API_URL");
+            SessionToken = System.Environment.GetEnvironmentVariable("CLERK_SESSION_TOKEN") ?? "";
+            Audiences = null;
+            AuthorizedParties = new List<string> { RequestUrl };
+
+            (TestToken, TestJwtKey) = Utils.GenerateTokenKeyPair(
+                keyId: "ins_abcdefghijklmnopqrstuvwxyz0",
+                issuedAt: DateTime.UtcNow.AddMinutes(-1),
+                notBefore: DateTime.UtcNow,
+                expires: DateTime.UtcNow.AddMinutes(1),
+                audience: RequestUrl,
+                authorizedParties: AuthorizedParties);
+        }
+    }
+
+    public class ConditionalFactAttribute : FactAttribute
+    {
+        public ConditionalFactAttribute(params string[] envVars)
+        {
+            var missingEnvVars = new List<string>();
+            foreach (var envVar in envVars)
+            {
+                if (string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(envVar)))
+                {
+                    missingEnvVars.Add(envVar);
+                }
+            }
+            if (missingEnvVars.Count > 0)
+            {
+                Skip = $"Missing environment variable(s): {string.Join(", ", missingEnvVars)}.";
+            }
+        }
+    }
+
+    public class Utils
+    {
+
+        internal static void WarnTokenIsExpired(string? message = "")
+        {
+            System.Console.WriteLine($"WARNING: the provided session token is expired! {message}");
+        }
+
+        internal static async Task AssertClaimsAsync(string sessionToken, VerifyTokenOptions options)
+        {
+            bool expired = false;
+            ClaimsPrincipal? claims = null;
+
+            try
+            {
+                claims = await VerifyToken.VerifyTokenAsync(sessionToken, options);
+            }
+            catch (TokenVerificationException ex)
+            {
+                if (ex.Reason != TokenVerificationErrorReason.TOKEN_EXPIRED)
+                {
+                    throw;
+                }
+
+                Assert.IsType<SecurityTokenExpiredException>(ex.InnerException);
+                Assert.Contains("Lifetime validation failed. The token is expired.", ex.InnerException.Message);
+                expired = true;
+                WarnTokenIsExpired();
+            }
+
+            if (!expired)
+            {
+                Assert.NotNull(claims);
+                Assert.NotNull(claims.FindFirst("iss"));
+            }
+        }
+
+        internal static void AssertStateAsync(RequestState state, string token)
+        {
+            if (state.IsSignedIn())
+            {
+                Assert.Null(state.ErrorReason);
+                Assert.Equal(token, state.Token);
+                Assert.NotNull(state.Claims);
+            }
+            else
+            {
+                Assert.Equal(TokenVerificationErrorReason.TOKEN_EXPIRED, state.ErrorReason);
+                Assert.Null(state.Token);
+                Assert.Null(state.Claims);
+                WarnTokenIsExpired();
+            }
+        }
+
+        internal static Tuple<string, string> GenerateTokenKeyPair(
+            string? keyId = null,
+            DateTime? issuedAt = null,
+            DateTime? notBefore = null,
+            DateTime? expires = null,
+            string? audience = null,
+            IEnumerable<string>? authorizedParties = null)
+        {
+            var rsa = RSA.Create(2048);
+            var rsaSecurityKey = new RsaSecurityKey(rsa)
+            {
+                KeyId = keyId ?? "ins_abcdefghijklmnopqrstuvwxyz0"
+            };
+            var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+            var subjectClaims = new List<Claim> { new Claim(ClaimTypes.Name, "Test") };
+            if (authorizedParties != null)
+            {
+                foreach (var party in authorizedParties)
+                {
+                    subjectClaims.Add(new Claim("azp", party));
+                }
+            }
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                SigningCredentials = signingCredentials,
+                Subject = new ClaimsIdentity(subjectClaims),
+                Issuer = "https://test.com",
+                Audience = audience,
+                IssuedAt = issuedAt ?? DateTime.UtcNow.AddMinutes(-1),
+                NotBefore = notBefore ?? DateTime.UtcNow,
+                Expires = expires ?? DateTime.UtcNow.AddMinutes(1)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            var tokenString = tokenHandler.WriteToken(token);
+
+            var publicKeyBytes = rsa.ExportSubjectPublicKeyInfo();
+            var pem = new StringBuilder();
+            pem.AppendLine("-----BEGIN PUBLIC KEY-----");
+            pem.AppendLine(Convert.ToBase64String(publicKeyBytes, Base64FormattingOptions.InsertLineBreaks));
+            pem.AppendLine("-----END PUBLIC KEY-----");
+
+            return new Tuple<string, string>(tokenString, pem.ToString());
+        }
+    }
+}

--- a/tests/JwksHelpers/Utils.cs
+++ b/tests/JwksHelpers/Utils.cs
@@ -30,10 +30,10 @@ namespace JwksHelpers.Tests
 
         public JwksHelpersFixture()
         {
-            SecretKey = System.Environment.GetEnvironmentVariable("CLERK_SECRET_KEY");
-            JwtKey = System.Environment.GetEnvironmentVariable("CLERK_JWT_KEY");
-            ApiUrl = System.Environment.GetEnvironmentVariable("CLERK_API_URL");
-            SessionToken = System.Environment.GetEnvironmentVariable("CLERK_SESSION_TOKEN") ?? "";
+            SecretKey = Environment.GetEnvironmentVariable("CLERK_SECRET_KEY");
+            JwtKey = Environment.GetEnvironmentVariable("CLERK_JWT_KEY");
+            ApiUrl = Environment.GetEnvironmentVariable("CLERK_API_URL");
+            SessionToken = Environment.GetEnvironmentVariable("CLERK_SESSION_TOKEN") ?? "";
             Audiences = null;
             AuthorizedParties = new List<string> { RequestUrl };
 

--- a/tests/JwksHelpers/VerifyTokenTests.cs
+++ b/tests/JwksHelpers/VerifyTokenTests.cs
@@ -1,0 +1,267 @@
+#nullable enable
+namespace JwksHelpers.Tests
+{
+    using Xunit;
+    using Clerk.BackendAPI.Helpers.Jwks;
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+    using System.Text;
+    using Microsoft.IdentityModel.Tokens;
+
+    public class VerifyTokenTests : IClassFixture<JwksHelpersFixture>
+    {
+        private readonly JwksHelpersFixture fixture;
+
+        public VerifyTokenTests(JwksHelpersFixture jwksHelpersFixture)
+        {
+            fixture = jwksHelpersFixture;
+        }
+
+        [Fact]
+        public void TestVerifyTokenNoSecretKey ()
+        {
+
+            var ex = Assert.Throws<TokenVerificationException>(
+                () => new VerifyTokenOptions()
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.SECRET_KEY_MISSING, ex.Reason);
+            Assert.Contains("Missing Clerk Secret Key.", ex.ToString());
+            Assert.Null(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenInvalidSecretKey ()
+        {
+            var vtOptions = new VerifyTokenOptions(secretKey: "sk_test_invalid");
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.JWK_FAILED_TO_LOAD, ex.Reason);
+            Assert.Null(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenInvalidJwtKey ()
+        {
+            var (token, jwtKey) = Utils.GenerateTokenKeyPair();
+            var vtOptions = new VerifyTokenOptions(jwtKey: "invalid.jwt.key");
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.JWK_LOCAL_INVALID, ex.Reason);
+            Assert.IsType<System.ArgumentException>(ex.InnerException);
+            Assert.Contains("No supported key formats were found.", ex.InnerException.Message);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenInvalidSignature ()
+        {
+            var vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.TestJwtKey!.Replace("+", "0")  // tampering with the key
+            );
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_INVALID_SIGNATURE, ex.Reason);
+            Assert.IsAssignableFrom<SecurityTokenInvalidSignatureException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenNotActiveYet ()
+        {
+            var (token, jwtKey) = Utils.GenerateTokenKeyPair(
+                notBefore: DateTime.UtcNow.AddSeconds(10)
+            );
+
+            var vtOptions = new VerifyTokenOptions(jwtKey: jwtKey);
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(token, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_NOT_ACTIVE_YET, ex.Reason);
+            Assert.IsType<SecurityTokenNotYetValidException>(ex.InnerException);
+            Assert.Contains("Lifetime validation failed.", ex.InnerException.Message);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenClockSkew ()
+        {
+            var (token, jwtKey) = Utils.GenerateTokenKeyPair(
+                issuedAt: DateTime.UtcNow.AddMinutes(-1),
+                notBefore: DateTime.UtcNow.AddSeconds(10),
+                expires: DateTime.UtcNow.AddMinutes(2)
+            );
+
+            var vtOptions = new VerifyTokenOptions(jwtKey: jwtKey, clockSkewInMs: 0);
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(token, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_NOT_ACTIVE_YET, ex.Reason);
+            Assert.IsType<SecurityTokenNotYetValidException>(ex.InnerException);
+
+            vtOptions = new VerifyTokenOptions(jwtKey: jwtKey, clockSkewInMs: 10000);
+            var claims = await VerifyToken.VerifyTokenAsync(token, vtOptions);
+            Assert.NotNull(claims.FindFirst("nbf").Value);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenExpired ()
+        {
+            var (token, jwtKey) = Utils.GenerateTokenKeyPair(
+                issuedAt: DateTime.UtcNow.AddMinutes(-3),
+                notBefore: DateTime.UtcNow.AddMinutes(-2),
+                expires: DateTime.UtcNow.AddMinutes(-1)
+            );
+
+            var vtOptions = new VerifyTokenOptions(jwtKey: jwtKey);
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(token, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_EXPIRED, ex.Reason);
+            Assert.IsType<SecurityTokenExpiredException>(ex.InnerException);
+            Assert.Contains("Lifetime validation failed.", ex.InnerException.Message);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenIssuedInTheFuture ()
+        {
+            var (token, jwtKey) = Utils.GenerateTokenKeyPair(
+                issuedAt: DateTime.UtcNow.AddMinutes(1),
+                notBefore: DateTime.UtcNow.AddMinutes(-1),
+                expires: DateTime.UtcNow.AddMinutes(2)
+            );
+
+            var vtOptions = new VerifyTokenOptions(jwtKey: jwtKey);
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(token, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_IAT_IN_THE_FUTURE, ex.Reason);
+            Assert.Null(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenInvalidAudience ()
+        {
+            var vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.TestJwtKey,
+                audiences: new string[] { fixture.RequestUrl }
+            );
+
+            var claims = await VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions);
+            var audClaim = claims.FindFirst("aud");
+            Assert.NotNull(audClaim);
+            Assert.Equal(fixture.RequestUrl, audClaim.Value);
+
+
+            vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.TestJwtKey,
+                audiences: new List<string> { "invalid.audience" }
+            );
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_INVALID_AUDIENCE, ex.Reason);
+            Assert.IsType<SecurityTokenInvalidAudienceException>(ex.InnerException);
+            Assert.Contains("Audience validation failed.", ex.InnerException.Message);
+        }
+
+        [Fact]
+        public async Task TestVerifyTokenInvalidAuthorizedParties ()
+        {
+            var vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.TestJwtKey,
+                authorizedParties: fixture.AuthorizedParties
+            );
+
+            var claims = await VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions);
+            var azpClaim = claims.FindFirst("azp");
+            Assert.NotNull(azpClaim);
+            Assert.True(fixture.AuthorizedParties.Contains(azpClaim.Value));
+
+            vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.TestJwtKey,
+                authorizedParties: new string[] { "http://only.authorized.party" }
+            );
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_INVALID_AUTHORIZED_PARTIES, ex.Reason);
+            Assert.Null(ex.InnerException);
+
+        }
+
+        [ConditionalFact("CLERK_SECRET_KEY")]
+        public async Task TestVerifyTokenInvalidToken ()
+        {
+            var vtOptions = new VerifyTokenOptions(secretKey: fixture.SecretKey);
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync("invalid.session.token", vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.TOKEN_INVALID, ex.Reason);
+            Assert.IsType<ArgumentException>(ex.InnerException);
+            Assert.Contains("IDX12729: Unable to decode the header", ex.InnerException.Message);
+        }
+
+
+        [ConditionalFact("CLERK_SECRET_KEY")]
+        public async Task TestVerifyTokenInvalidKid ()
+        {
+            var token = Utils.GenerateTokenKeyPair().Item1;
+
+            var vtOptions = new VerifyTokenOptions(secretKey: fixture.SecretKey);
+
+            var ex = await Assert.ThrowsAsync<TokenVerificationException>(
+                () => VerifyToken.VerifyTokenAsync(token, vtOptions)
+            );
+
+            Assert.Equal(TokenVerificationErrorReason.JWK_KID_MISMATCH, ex.Reason);
+            Assert.Null(ex.InnerException);
+        }
+
+        [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
+        public async Task TestVerifyTokenRemoteOk ()
+        {
+            var vtOptions = new VerifyTokenOptions(
+                secretKey: fixture.SecretKey,
+                audiences: fixture.Audiences,
+                authorizedParties: fixture.AuthorizedParties,
+                apiUrl: fixture.ApiUrl
+            );
+
+            await Utils.AssertClaimsAsync(fixture.SessionToken, vtOptions);
+        }
+
+        [ConditionalFact("CLERK_JWT_KEY", "CLERK_SESSION_TOKEN")]
+        public async Task TestVerifyTokenLocalOk ()
+        {
+            var vtOptions = new VerifyTokenOptions(
+                jwtKey: fixture.JwtKey,
+                audiences: fixture.Audiences,
+                authorizedParties: fixture.AuthorizedParties,
+                apiUrl: fixture.ApiUrl
+            );
+
+            await Utils.AssertClaimsAsync(fixture.SessionToken, vtOptions);
+        }
+
+    }
+}

--- a/tests/JwksHelpers/VerifyTokenTests.cs
+++ b/tests/JwksHelpers/VerifyTokenTests.cs
@@ -21,7 +21,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public void TestVerifyTokenNoSecretKey ()
+        public void TestVerifyTokenNoSecretKey()
         {
 
             var ex = Assert.Throws<TokenVerificationException>(
@@ -34,7 +34,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenInvalidSecretKey ()
+        public async Task TestVerifyTokenInvalidSecretKey()
         {
             var vtOptions = new VerifyTokenOptions(secretKey: "sk_test_invalid");
 
@@ -47,7 +47,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenInvalidJwtKey ()
+        public async Task TestVerifyTokenInvalidJwtKey()
         {
             var (token, jwtKey) = Utils.GenerateTokenKeyPair();
             var vtOptions = new VerifyTokenOptions(jwtKey: "invalid.jwt.key");
@@ -62,7 +62,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenInvalidSignature ()
+        public async Task TestVerifyTokenInvalidSignature()
         {
             var vtOptions = new VerifyTokenOptions(
                 jwtKey: fixture.TestJwtKey!.Replace("+", "0")  // tampering with the key
@@ -77,7 +77,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenNotActiveYet ()
+        public async Task TestVerifyTokenNotActiveYet()
         {
             var (token, jwtKey) = Utils.GenerateTokenKeyPair(
                 notBefore: DateTime.UtcNow.AddSeconds(10)
@@ -94,11 +94,14 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenClockSkew ()
+        public async Task TestVerifyTokenClockSkew()
         {
+            var nbfDateTime = DateTime.UtcNow.AddSeconds(10);
+            var nbfTimeStamp = ((DateTimeOffset)nbfDateTime).ToUnixTimeSeconds();
+
             var (token, jwtKey) = Utils.GenerateTokenKeyPair(
                 issuedAt: DateTime.UtcNow.AddMinutes(-1),
-                notBefore: DateTime.UtcNow.AddSeconds(10),
+                notBefore: nbfDateTime,
                 expires: DateTime.UtcNow.AddMinutes(2)
             );
 
@@ -112,11 +115,13 @@ namespace JwksHelpers.Tests
 
             vtOptions = new VerifyTokenOptions(jwtKey: jwtKey, clockSkewInMs: 10000);
             var claims = await VerifyToken.VerifyTokenAsync(token, vtOptions);
-            Assert.NotNull(claims.FindFirst("nbf").Value);
+            var nbfClaim = claims.FindFirst("nbf");
+            Assert.NotNull(nbfClaim);
+            Assert.Equal(nbfTimeStamp.ToString(), nbfClaim.Value);
         }
 
         [Fact]
-        public async Task TestVerifyTokenExpired ()
+        public async Task TestVerifyTokenExpired()
         {
             var (token, jwtKey) = Utils.GenerateTokenKeyPair(
                 issuedAt: DateTime.UtcNow.AddMinutes(-3),
@@ -135,7 +140,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenIssuedInTheFuture ()
+        public async Task TestVerifyTokenIssuedInTheFuture()
         {
             var (token, jwtKey) = Utils.GenerateTokenKeyPair(
                 issuedAt: DateTime.UtcNow.AddMinutes(1),
@@ -153,7 +158,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenInvalidAudience ()
+        public async Task TestVerifyTokenInvalidAudience()
         {
             var vtOptions = new VerifyTokenOptions(
                 jwtKey: fixture.TestJwtKey,
@@ -181,7 +186,7 @@ namespace JwksHelpers.Tests
         }
 
         [Fact]
-        public async Task TestVerifyTokenInvalidAuthorizedParties ()
+        public async Task TestVerifyTokenInvalidAuthorizedParties()
         {
             var vtOptions = new VerifyTokenOptions(
                 jwtKey: fixture.TestJwtKey,
@@ -191,7 +196,7 @@ namespace JwksHelpers.Tests
             var claims = await VerifyToken.VerifyTokenAsync(fixture.TestToken, vtOptions);
             var azpClaim = claims.FindFirst("azp");
             Assert.NotNull(azpClaim);
-            Assert.True(fixture.AuthorizedParties.Contains(azpClaim.Value));
+            Assert.Contains(azpClaim.Value, fixture.AuthorizedParties);
 
             vtOptions = new VerifyTokenOptions(
                 jwtKey: fixture.TestJwtKey,
@@ -208,7 +213,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_SECRET_KEY")]
-        public async Task TestVerifyTokenInvalidToken ()
+        public async Task TestVerifyTokenInvalidToken()
         {
             var vtOptions = new VerifyTokenOptions(secretKey: fixture.SecretKey);
 
@@ -223,7 +228,7 @@ namespace JwksHelpers.Tests
 
 
         [ConditionalFact("CLERK_SECRET_KEY")]
-        public async Task TestVerifyTokenInvalidKid ()
+        public async Task TestVerifyTokenInvalidKid()
         {
             var token = Utils.GenerateTokenKeyPair().Item1;
 
@@ -238,7 +243,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_SECRET_KEY", "CLERK_SESSION_TOKEN")]
-        public async Task TestVerifyTokenRemoteOk ()
+        public async Task TestVerifyTokenRemoteOk()
         {
             var vtOptions = new VerifyTokenOptions(
                 secretKey: fixture.SecretKey,
@@ -251,7 +256,7 @@ namespace JwksHelpers.Tests
         }
 
         [ConditionalFact("CLERK_JWT_KEY", "CLERK_SESSION_TOKEN")]
-        public async Task TestVerifyTokenLocalOk ()
+        public async Task TestVerifyTokenLocalOk()
         {
             var vtOptions = new VerifyTokenOptions(
                 jwtKey: fixture.JwtKey,

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+    <PackageReference Include="newtonsoft.json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Clerk\BackendAPI\Clerk.BackendAPI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR implements [authenticateRequest](https://clerk.com/docs/references/backend/authenticate-request) and [verifyToken](https://clerk.com/docs/references/backend/verify-token) helper methods.

#### Notes
- the `src/clerk/BackendAPI/Helpers/` folder is *.genignored*
- unlike in the `clerk-sdk-python` implementation, the `secretKey` should be passed manually. Due to [SDKConfiguration](https://github.com/clerk/clerk-sdk-csharp/blob/faf693a7c9e60d8ea91c571d460821b6f87cd6ca/src/Clerk/BackendAPI/Jwks.cs#L39) being a private member of the `Jwks` SubSDK class, the `bearerAuth` value passed during sdk instantiation cannot be reused as `secretKey` for convenience.

#### Limitations
- the added helper functions are only applicable for Backend APIs, `afterSignInUrl`/`afterSignUpUrl` options are not implemented
- multi-domain setup (`isSatellite`, `proxyUrl`, `signInUrl`, `signUpUrl`) is not implemented
- caching is not covered by this PR and `skipJwksCache` option is not made available

#### Tests
To run all tests (`dotnet test`) the following environment variables should be set:
- `CLERK_SESSION_TOKEN`: The session token to be tested.
- `CLERK_SECRET_KEY`: The Clerk secret key from the API Keys page in the Clerk Dashboard (needed for fetching Clerk's Jwks)
- `CLERK_JWT_KEY`: The PEM public key from Clerk Dashboard (needed for networkless verification only)

#### Example Usage
1. Remote JWKS (using `secretKey`)
```csharp
using Clerk.BackendAPI.Helpers.Jwks;
using System;
using System.Net.Http;
using System.Threading.Tasks;

public class UserAuthentication
{
    public static async Task<bool> IsSignedInAsync(HttpRequestMessage request)
    {
        var options = new AuthenticateRequestOptions(
            secretKey: Environment.GetEnvironmentVariable("CLERK_SECRET_KEY"),
            authorizedParties: new string[] { "https://example.com" }
        );

        var requestState = await AuthenticateRequest.AuthenticateRequestAsync(request, options);

        return requestState.isSignedIn();
    }
}
```

2. Networkless (using local PEM formatted `jwtKey`)
```csharp
using Clerk.BackendAPI.Helpers.Jwks;
using System;
using System.Net.Http;
using System.Threading.Tasks;

public class UserAuthentication
{
    public static async Task<bool> IsSignedInAsync(HttpRequestMessage request)
    {
        var options = new AuthenticateRequestOptions(
            secretKey: Environment.GetEnvironmentVariable("CLERK_JWT_KEY"),
            authorizedParties: new string[] { "https://example.com" }
        );

        var requestState = await AuthenticateRequest.AuthenticateRequestAsync(request, options);

        return requestState.isSignedIn();
    }
}
```