### PR TITLE
chore: add ticket to Oauth and OTP strategy enums

### DIFF
--- a/fixes.yaml
+++ b/fixes.yaml
@@ -16,6 +16,7 @@ actions:
       - "from_oauth_apple"
       - "from_oauth_microsoft"
       - "from_oauth_github"
+      - "ticket"
   - target: $["components"]["schemas"]["Oauth"]["properties"]["strategy"]["enum"][*]
     remove: true
   - target: $["components"]["schemas"]["Oauth"]["properties"]["strategy"]["enum"]
@@ -29,6 +30,7 @@ actions:
       - "oauth_microsoft"
       - "oauth_github"
       - "email_link"
+      - "ticket"
   - target: $["components"]["schemas"]["IdentificationLink"]["properties"]["type"]["enum"]
     update:
       - "oauth_apple"


### PR DESCRIPTION
A end user reported a union deserialization failure for the [Users.GetAsync](https://github.com/clerk/clerk-sdk-csharp/blob/main/src/Clerk/BackendAPI/Users.cs#L572) method. 

The issue was isolated to the email addresses [Verification](https://github.com/clerk/clerk-sdk-csharp/blob/main/src/Clerk/BackendAPI/Models/Components/Verification.cs#L39).

The incoming data contained a strategy called "ticket":
```
"verification": {
        "status": "verified",
        "strategy": "ticket",
        "attempts": null,
        "expire_at": null
      },
```
which was not represented in any of the strategy enums available:
- [Otp](https://github.com/clerk/clerk-sdk-csharp/blob/main/src/Clerk/BackendAPI/Models/Components/Strategy.cs#L16)
- [Admin](https://github.com/clerk/clerk-sdk-csharp/blob/main/src/Clerk/BackendAPI/Models/Components/AdminVerificationStrategy.cs#L16)
- [Oauth](https://github.com/clerk/clerk-sdk-csharp/blob/main/src/Clerk/BackendAPI/Models/Components/OauthVerificationStrategy.cs#L16)

This PR adds the `ticket` strategy to the `Oauth` and `Otp` enums