### PR TITLE
fix: WellKnownJWKS model renamed

### DIFF
--- a/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
+++ b/src/Clerk/BackendAPI/Helpers/VerifyToken.cs
@@ -11,6 +11,8 @@ using Clerk.BackendAPI.Utils;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 
+using WellKnownJWKS = Clerk.BackendAPI.Models.Components.Jwks;
+
 namespace Clerk.BackendAPI.Helpers.Jwks;
 
 public static class VerifyToken


### PR DESCRIPTION
The `WellKnown.JWKS` component used to be defined as a `schema`:
```
  schemas:
    WellKnown.JWKS:
      type: object
      additionalProperties: false
      properties:
        keys:
          type: array
          items:
            type: object
            properties:
              ...
```

_Models/Components/WellKnownJWKS.cs_
```
namespace Clerk.BackendAPI.Models.Components
{
    using Clerk.BackendAPI.Models.Components;
    using Clerk.BackendAPI.Utils;
    using Newtonsoft.Json;
    using System.Collections.Generic;

    /// <summary>
    /// Get the JSON Web Key Set
    /// </summary>
    public class WellKnownJWKS
    {

        [JsonProperty("keys")]
        public List<Keys>? Keys { get; set; }
    }
}
```

but is now expected to being nested inside a `response`:
```
  responses:
    WellKnown.JWKS:
      description: Get the JSON Web Key Set
      content:
        application/json:
          schema:
            $ref: "#/components/schemas/JWKS"
```

_Models/Operations/GetJWKSResponse.cs_
```
namespace Clerk.BackendAPI.Models.Operations
{
    using Clerk.BackendAPI.Models.Components;
    using Clerk.BackendAPI.Utils;
    using Newtonsoft.Json;

    public class GetJWKSResponse
    {

        [JsonProperty("-")]
        public HTTPMetadata HttpMeta { get; set; } = default!;

        /// <summary>
        /// Get the JSON Web Key Set
        /// </summary>
        public Models.Components.Jwks? Jwks { get; set; }
    }
}
```

This means `Models.Components.WellKnownJWKS` needs to be renamed to `Models.Components.Jwks`
to prevent [generation failure](https://github.com/clerk/clerk-sdk-csharp/actions/runs/12936895260/job/36083558169#step:5:1438)

This PR uses a type alias to prevent namespace conflict with the `Clerk.BackendAPI.Helpers.Jwks` namespace.
