### PR TITLE
Add telemetry

### DIFF
--- a/src/Clerk/BackendAPI/Hooks/ClerkBeforeRequestHook.cs
+++ b/src/Clerk/BackendAPI/Hooks/ClerkBeforeRequestHook.cs
@@ -5,10 +5,10 @@ namespace Clerk.BackendAPI.Hooks
 
     public class ClerkBeforeRequestHook : IBeforeRequestHook
     {
-        public async Task<HttpRequestMessage> BeforeRequestAsync(BeforeRequestContext hookCtx, HttpRequestMessage request)
+        public Task<HttpRequestMessage> BeforeRequestAsync(BeforeRequestContext hookCtx, HttpRequestMessage request)
         {
             request.Headers.Add("Clerk-API-Version", "2024-10-01");
-            return request;
+            return Task.FromResult(request);
         }
     }
 }

--- a/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
+++ b/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
@@ -1,6 +1,10 @@
 
 namespace Clerk.BackendAPI.Hooks
 {
+    using System;
+    using System.Collections.Generic;
+    using Clerk.BackendAPI.Hooks.Telemetry;
+
     /// <summary>
     /// Hook Registration File.
     /// </summary>
@@ -28,10 +32,17 @@ namespace Clerk.BackendAPI.Hooks
             var clerkBeforeRequestHook = new ClerkBeforeRequestHook();
             hooks.RegisterBeforeRequestHook(clerkBeforeRequestHook);
 
-            // hooks.RegisterSDKInitHook(myHook);
-            // hooks.RegisterBeforeRequestHook(myHook);
-            // hooks.RegisterAfterSuccessHook(myHook);
-            // hooks.RegisterAfterErrorHook(myHook;
+            // Register telemetry hooks
+            var telemetryCollectors = new List<ITelemetryCollector> { new DebugTelemetryCollector(), LiveTelemetryCollector.Standard() };
+
+            var telemetryBeforeRequestHook = new TelemetryBeforeRequestHook(telemetryCollectors);
+            hooks.RegisterBeforeRequestHook(telemetryBeforeRequestHook);
+            
+            var telemetryAfterSuccessHook = new TelemetryAfterSuccessHook(telemetryCollectors);
+            hooks.RegisterAfterSuccessHook(telemetryAfterSuccessHook);
+            
+            var telemetryAfterErrorHook = new TelemetryAfterErrorHook(telemetryCollectors);
+            hooks.RegisterAfterErrorHook(telemetryAfterErrorHook);
         }
     }
 }

--- a/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
+++ b/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
@@ -1,4 +1,3 @@
-
 namespace Clerk.BackendAPI.Hooks
 {
     using System;
@@ -33,6 +32,20 @@ namespace Clerk.BackendAPI.Hooks
             hooks.RegisterBeforeRequestHook(clerkBeforeRequestHook);
 
             // Register telemetry hooks
+            RegisterTelemetryHooks(hooks);
+        }
+
+        /// <summary>
+        /// Registers telemetry hooks for collecting usage data.
+        /// </summary>
+        /// <param name="hooks">The hooks registry to add telemetry hooks to.</param>
+        private static void RegisterTelemetryHooks(IHooks hooks)
+        {
+
+            if (Environment.GetEnvironmentVariable("CLERK_TELEMETRY_DISABLED") == "1") {
+                return;
+            }
+
             var telemetryCollectors = new List<ITelemetryCollector> { LiveTelemetryCollector.Standard() };
             if (Environment.GetEnvironmentVariable("CLERK_TELEMETRY_DEBUG") == "1") {
                 telemetryCollectors.Add(new DebugTelemetryCollector());

--- a/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
+++ b/src/Clerk/BackendAPI/Hooks/HookRegistration.cs
@@ -33,7 +33,10 @@ namespace Clerk.BackendAPI.Hooks
             hooks.RegisterBeforeRequestHook(clerkBeforeRequestHook);
 
             // Register telemetry hooks
-            var telemetryCollectors = new List<ITelemetryCollector> { new DebugTelemetryCollector(), LiveTelemetryCollector.Standard() };
+            var telemetryCollectors = new List<ITelemetryCollector> { LiveTelemetryCollector.Standard() };
+            if (Environment.GetEnvironmentVariable("CLERK_TELEMETRY_DEBUG") == "1") {
+                telemetryCollectors.Add(new DebugTelemetryCollector());
+            }
 
             var telemetryBeforeRequestHook = new TelemetryBeforeRequestHook(telemetryCollectors);
             hooks.RegisterBeforeRequestHook(telemetryBeforeRequestHook);

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/PreparedEvent.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/PreparedEvent.cs
@@ -1,0 +1,42 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System.Collections.Generic;
+
+    public class PreparedEvent
+    {
+        public string Event { get; }
+        public string It { get; }
+        public string Sdk { get; }
+        public string Sdkv { get; }
+        public string Sk { get; }
+        public Dictionary<string, string> Payload { get; }
+
+        public PreparedEvent(string @event, string it, string sdk, string sdkv, string sk, Dictionary<string, string> payload)
+        {
+            Event = @event;
+            It = it;
+            Sdk = sdk;
+            Sdkv = sdkv;
+            Sk = sk;
+            Payload = payload;
+        }
+
+        public SortedDictionary<string, string> Sanitize()
+        {
+            var sanitizedEvent = new SortedDictionary<string, string>
+            {
+                ["event"] = Event,
+                ["it"] = It,
+                ["sdk"] = Sdk,
+                ["sdkv"] = Sdkv
+            };
+
+            foreach (var item in Payload)
+            {
+                sanitizedEvent[item.Key] = item.Value;
+            }
+
+            return sanitizedEvent;
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/SdkInfo.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/SdkInfo.cs
@@ -1,0 +1,50 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using System.Xml;
+
+    public class SdkInfo
+    {
+        public string Version { get; }
+        public string Name { get; }
+        public string GroupId { get; }
+
+        public SdkInfo(string version, string name, string groupId)
+        {
+            Version = version;
+            Name = name;
+            GroupId = groupId;
+        }
+
+        public override string ToString()
+        {
+            return $"{{\"version\":\"{Version}\",\"name\":\"{Name}\",\"groupId\":\"{GroupId}\"}}";
+        }
+
+        public static SdkInfo? LoadFromAssembly()
+        {
+            try
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var assemblyName = assembly.GetName();
+                
+                // Get the version from the assembly
+                var version = assemblyName.Version?.ToString() ?? "unknown";
+                
+                // Get the name (without namespace)
+                var name = assemblyName.Name ?? "unknown";
+                
+                // For .NET we'll use the first part of the namespace as groupId
+                var groupId = name.Contains('.') ? name.Substring(0, name.IndexOf('.')) : "Clerk";
+
+                return new SdkInfo(version, name, groupId);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryAfterErrorHook.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryAfterErrorHook.cs
@@ -1,0 +1,47 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    public class TelemetryAfterErrorHook : IAfterErrorHook
+    {
+        // Visible for testing
+        public readonly List<ITelemetryCollector> Collectors;
+
+        public TelemetryAfterErrorHook(List<ITelemetryCollector> collectors)
+        {
+            Collectors = collectors;
+        }
+
+        public Task<(HttpResponseMessage?, Exception?)> AfterErrorAsync(AfterErrorContext context, HttpResponseMessage? response, Exception? error)
+        {
+            var additionalPayload = new Dictionary<string, string>();
+            
+            if (response != null)
+            {
+                additionalPayload["status_code"] = ((int)response.StatusCode).ToString();
+            }
+            
+            if (error != null)
+            {
+                additionalPayload["error_message"] = error.Message;
+            }
+
+            TelemetryEvent @event = TelemetryEvent.FromContext(
+                context,
+                TelemetryEvent.EVENT_METHOD_FAILED,
+                0.1f,
+                additionalPayload
+            );
+
+            foreach (var collector in Collectors)
+            {
+                collector.Collect(@event);
+            }
+
+            return Task.FromResult((response, error));
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryAfterSuccessHook.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryAfterSuccessHook.cs
@@ -1,0 +1,39 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    public class TelemetryAfterSuccessHook : IAfterSuccessHook
+    {
+        // Visible for testing
+        public readonly List<ITelemetryCollector> Collectors;
+
+        public TelemetryAfterSuccessHook(List<ITelemetryCollector> collectors)
+        {
+            Collectors = collectors;
+        }
+
+        public Task<HttpResponseMessage> AfterSuccessAsync(AfterSuccessContext context, HttpResponseMessage response)
+        {
+            var additionalPayload = new Dictionary<string, string>
+            {
+                ["status_code"] = ((int)response.StatusCode).ToString()
+            };
+
+            TelemetryEvent @event = TelemetryEvent.FromContext(
+                context,
+                TelemetryEvent.EVENT_METHOD_SUCCEEDED,
+                0.1f,
+                additionalPayload
+            );
+
+            foreach (var collector in Collectors)
+            {
+                collector.Collect(@event);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryBeforeRequestHook.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryBeforeRequestHook.cs
@@ -1,0 +1,35 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    public class TelemetryBeforeRequestHook : IBeforeRequestHook
+    {
+        // Visible for testing
+        public readonly List<ITelemetryCollector> Collectors;
+
+        public TelemetryBeforeRequestHook(List<ITelemetryCollector> collectors)
+        {
+            Collectors = collectors;
+        }
+
+        public Task<HttpRequestMessage> BeforeRequestAsync(BeforeRequestContext context, HttpRequestMessage request)
+        {
+            TelemetryEvent @event = TelemetryEvent.FromContext(
+                context,
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                0.1f,
+                new Dictionary<string, string>()
+            );
+
+            foreach (var collector in Collectors)
+            {
+                collector.Collect(@event);
+            }
+
+            return Task.FromResult(request);
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
@@ -33,7 +33,7 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
             }
         }
 
-        protected string SerializeToJson(PreparedEvent preparedEvent)
+        protected virtual string SerializeToJson(PreparedEvent preparedEvent)
         {
             return JsonSerializer.Serialize(preparedEvent);
         }

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
@@ -35,7 +35,9 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
 
         protected virtual string SerializeToJson(PreparedEvent preparedEvent)
         {
-            return JsonSerializer.Serialize(preparedEvent);
+            // Convert to sanitized dictionary with lowercase keys then serialize
+            var sanitizedEvent = preparedEvent.Sanitize();
+            return JsonSerializer.Serialize(sanitizedEvent);
         }
 
         protected PreparedEvent PrepareEvent(TelemetryEvent @event)

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
@@ -86,7 +86,7 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
             PreparedEvent preparedEvent = PrepareEvent(@event);
             foreach (var sampler in _samplers)
             {
-                if (!sampler.Test(preparedEvent, @event))
+                if (!sampler.shouldSample(preparedEvent, @event))
                 {
                     return;
                 }

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
@@ -112,33 +112,18 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
                 
                 if (!response.IsSuccessStatusCode)
                 {
-                    LogWarning($"Failed to send telemetry event. Response code: {(int)response.StatusCode}, error: {responseContent}");
-                }
-                else
-                {
-                    LogDebug($"Telemetry event sent successfully. Response: {responseContent}");
+                    LogDebug($"Failed to send telemetry event. Response code: {(int)response.StatusCode}, error: {responseContent}");
                 }
             }
             catch (Exception ex)
             {
-                LogWarning($"Error sending telemetry event: {ex.Message}");
+                LogDebug($"Error sending telemetry event: {ex.Message}");
             }
         }
-
-        private void LogWarning(string message)
-        {
-            lock (_consoleLock)
-            {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Error.WriteLine(message);
-                Console.ResetColor();
-            }
-        }
-
         private void LogDebug(string message)
         {
             // Only log in debug mode or controlled by environment variable
-            if (Environment.GetEnvironmentVariable("CLERK_DEBUG") == "1")
+            if (Environment.GetEnvironmentVariable("CLERK_TELEMETRY_DEBUG") == "1")
             {
                 lock (_consoleLock)
                 {

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryCollector.cs
@@ -1,0 +1,159 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Http;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+
+    public interface ITelemetryCollector
+    {
+        void Collect(TelemetryEvent @event);
+    }
+
+    public abstract class BaseTelemetryCollector : ITelemetryCollector
+    {
+        protected readonly string Sdkv;
+        protected readonly string Sdk;
+
+        protected BaseTelemetryCollector()
+        {
+            var sdkInfo = SdkInfo.LoadFromAssembly();
+            Sdkv = sdkInfo?.Version ?? "unknown";
+            Sdk = sdkInfo != null ? $"{sdkInfo.GroupId}:{sdkInfo.Name}" : "csharp:unknown";
+        }
+
+        public void Collect(TelemetryEvent @event)
+        {
+            if (@event.It == "development")
+            {
+                CollectInternal(@event);
+            }
+        }
+
+        protected string SerializeToJson(PreparedEvent preparedEvent)
+        {
+            return JsonSerializer.Serialize(preparedEvent);
+        }
+
+        protected PreparedEvent PrepareEvent(TelemetryEvent @event)
+        {
+            return new PreparedEvent(
+                @event.Event,
+                @event.It,
+                Sdk,
+                Sdkv,
+                @event.Sk,
+                new Dictionary<string, string>(@event.Payload)
+            );
+        }
+
+        protected abstract void CollectInternal(TelemetryEvent @event);
+    }
+
+    public class DebugTelemetryCollector : BaseTelemetryCollector
+    {
+        protected override void CollectInternal(TelemetryEvent @event)
+        {
+            try
+            {
+                Console.Error.WriteLine(SerializeToJson(PrepareEvent(@event)));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to serialize event: {ex.Message}");
+            }
+        }
+    }
+
+    public class LiveTelemetryCollector : BaseTelemetryCollector
+    {
+        private const string Endpoint = "http://localhost:3000/";
+        private readonly List<ITelemetrySampler> _samplers;
+        private readonly HttpClient _httpClient;
+        private static readonly object _consoleLock = new object();
+
+        public LiveTelemetryCollector(List<ITelemetrySampler> samplers)
+        {
+            _samplers = samplers;
+            _httpClient = new HttpClient();
+        }
+
+        protected override void CollectInternal(TelemetryEvent @event)
+        {
+            PreparedEvent preparedEvent = PrepareEvent(@event);
+            foreach (var sampler in _samplers)
+            {
+                if (!sampler.Test(preparedEvent, @event))
+                {
+                    return;
+                }
+            }
+
+            Task.Run(() => SendEventAsync(@event));
+        }
+
+        private async Task SendEventAsync(TelemetryEvent @event)
+        {
+            try
+            {
+                PreparedEvent preparedEvent = PrepareEvent(@event);
+                string eventJson = SerializeToJson(preparedEvent);
+                
+                var content = new StringContent(eventJson, Encoding.UTF8, "application/json");
+                
+                var response = await _httpClient.PostAsync(Endpoint, content);
+                
+                string responseContent = await response.Content.ReadAsStringAsync();
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    LogWarning($"Failed to send telemetry event. Response code: {(int)response.StatusCode}, error: {responseContent}");
+                }
+                else
+                {
+                    LogDebug($"Telemetry event sent successfully. Response: {responseContent}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWarning($"Error sending telemetry event: {ex.Message}");
+            }
+        }
+
+        private void LogWarning(string message)
+        {
+            lock (_consoleLock)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Error.WriteLine(message);
+                Console.ResetColor();
+            }
+        }
+
+        private void LogDebug(string message)
+        {
+            // Only log in debug mode or controlled by environment variable
+            if (Environment.GetEnvironmentVariable("CLERK_DEBUG") == "1")
+            {
+                lock (_consoleLock)
+                {
+                    Console.ForegroundColor = ConsoleColor.Gray;
+                    Console.Error.WriteLine(message);
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        public static LiveTelemetryCollector Standard()
+        {
+            return new LiveTelemetryCollector(new List<ITelemetrySampler>
+            {
+                // RandomSampler.Standard(),
+                DeduplicatingSampler.Standard()
+            });
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryEvent.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryEvent.cs
@@ -1,0 +1,99 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Text.Json;
+    using Clerk.BackendAPI.Models.Components;
+
+    public class TelemetryEvent
+    {
+        public const string EVENT_METHOD_CALLED = "METHOD_CALLED";
+        public const string EVENT_METHOD_SUCCEEDED = "METHOD_SUCCEEDED";
+        public const string EVENT_METHOD_FAILED = "METHOD_FAILED";
+
+        public string Sk { get; }
+        public string It { get; }
+        public string Event { get; }
+        public Dictionary<string, string> Payload { get; }
+        public float SamplingRate { get; }
+
+        public TelemetryEvent(
+            string sk,
+            string @event,
+            Dictionary<string, string> payload,
+            float samplingRate)
+        {
+            Sk = sk;
+            It = sk != null && sk.StartsWith("sk_test") ? "development" : "production";
+            Event = @event;
+            Payload = payload;
+            SamplingRate = samplingRate;
+        }
+
+        public static TelemetryEvent FromContext(
+            HookContext ctx,
+            string @event,
+            float samplingRate,
+            Dictionary<string, string> additionalPayload)
+        {
+            string sk = "unknown";
+            
+            // Extract bearer token from security source if available
+            if (ctx.SecuritySource != null)
+            {
+                Security securityObj = (Security)ctx.SecuritySource();
+                sk = securityObj?.BearerAuth ?? "unknown";
+            }
+
+            var payload = new Dictionary<string, string>
+            {
+                ["method"] = ctx.OperationID
+            };
+
+            foreach (var item in additionalPayload)
+            {
+                payload[item.Key] = item.Value;
+            }
+
+            return new TelemetryEvent(
+                sk,
+                @event,
+                payload,
+                samplingRate
+            );
+        }
+        
+        private static string ExtractBearerToken(object securityObj)
+        {
+            try 
+            {
+                // Since we know the implementation, we can check if the object has headerParams dictionary
+                var type = securityObj.GetType();
+                var headerParamsField = type.GetField("headerParams", BindingFlags.Instance | BindingFlags.NonPublic);
+                
+                if (headerParamsField != null)
+                {
+                    var headerParams = headerParamsField.GetValue(securityObj) as Dictionary<string, string>;
+                    
+                    if (headerParams != null && headerParams.TryGetValue("Authorization", out string authHeader))
+                    {
+                        // If it starts with "Bearer ", extract the token
+                        if (authHeader != null && authHeader.StartsWith("Bearer "))
+                        {
+                            return authHeader.Substring(7);
+                        }
+                        
+                        return authHeader ?? "unknown";
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore errors in extraction
+            }
+            
+            return "unknown";
+        }
+    }
+}

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryEvent.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetryEvent.cs
@@ -42,7 +42,8 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
             // Extract bearer token from security source if available
             if (ctx.SecuritySource != null)
             {
-                Security securityObj = (Security)ctx.SecuritySource();
+                var securitySource = ctx.SecuritySource();
+                Security? securityObj = securitySource is Security ? (Security)securitySource : null;
                 sk = securityObj?.BearerAuth ?? "unknown";
             }
 
@@ -62,38 +63,6 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
                 payload,
                 samplingRate
             );
-        }
-        
-        private static string ExtractBearerToken(object securityObj)
-        {
-            try 
-            {
-                // Since we know the implementation, we can check if the object has headerParams dictionary
-                var type = securityObj.GetType();
-                var headerParamsField = type.GetField("headerParams", BindingFlags.Instance | BindingFlags.NonPublic);
-                
-                if (headerParamsField != null)
-                {
-                    var headerParams = headerParamsField.GetValue(securityObj) as Dictionary<string, string>;
-                    
-                    if (headerParams != null && headerParams.TryGetValue("Authorization", out string authHeader))
-                    {
-                        // If it starts with "Bearer ", extract the token
-                        if (authHeader != null && authHeader.StartsWith("Bearer "))
-                        {
-                            return authHeader.Substring(7);
-                        }
-                        
-                        return authHeader ?? "unknown";
-                    }
-                }
-            }
-            catch
-            {
-                // Ignore errors in extraction
-            }
-            
-            return "unknown";
         }
     }
 }

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetrySampler.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetrySampler.cs
@@ -6,7 +6,7 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
 
     public interface ITelemetrySampler
     {
-        bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent);
+        bool shouldSample(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent);
     }
 
     public class RandomSampler : ITelemetrySampler
@@ -18,7 +18,7 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
             _random = random;
         }
 
-        public bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
+        public bool shouldSample(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
         {
             return _random.NextDouble() < telemetryEvent.SamplingRate;
         }
@@ -41,7 +41,7 @@ namespace Clerk.BackendAPI.Hooks.Telemetry
             _nowProvider = nowProvider;
         }
 
-        public bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
+        public bool shouldSample(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
         {
             try
             {

--- a/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetrySampler.cs
+++ b/src/Clerk/BackendAPI/Hooks/Telemetry/TelemetrySampler.cs
@@ -1,0 +1,69 @@
+namespace Clerk.BackendAPI.Hooks.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+
+    public interface ITelemetrySampler
+    {
+        bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent);
+    }
+
+    public class RandomSampler : ITelemetrySampler
+    {
+        private readonly Random _random;
+
+        public RandomSampler(Random random)
+        {
+            _random = random;
+        }
+
+        public bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
+        {
+            return _random.NextDouble() < telemetryEvent.SamplingRate;
+        }
+
+        public static RandomSampler Standard()
+        {
+            return new RandomSampler(new Random(1));
+        }
+    }
+
+    public class DeduplicatingSampler : ITelemetrySampler
+    {
+        private readonly Dictionary<string, DateTime> _cache = new Dictionary<string, DateTime>();
+        private readonly TimeSpan _window;
+        private readonly Func<DateTime> _nowProvider;
+
+        public DeduplicatingSampler(TimeSpan window, Func<DateTime> nowProvider)
+        {
+            _window = window;
+            _nowProvider = nowProvider;
+        }
+
+        public bool Test(PreparedEvent preparedEvent, TelemetryEvent telemetryEvent)
+        {
+            try
+            {
+                string key = JsonSerializer.Serialize(preparedEvent.Sanitize());
+                DateTime now = _nowProvider();
+
+                if (!_cache.TryGetValue(key, out DateTime lastSampled) || now - lastSampled > _window)
+                {
+                    _cache[key] = now;
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore serialization errors
+            }
+            return false;
+        }
+
+        public static DeduplicatingSampler Standard()
+        {
+            return new DeduplicatingSampler(TimeSpan.FromDays(1), () => DateTime.UtcNow);
+        }
+    }
+}

--- a/tests/Telemetry/PreparedEventTests.cs
+++ b/tests/Telemetry/PreparedEventTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Clerk.BackendAPI.Hooks.Telemetry;
+using Xunit;
+
+namespace Tests.Telemetry
+{
+    public class PreparedEventTests
+    {
+        [Fact]
+        public void Sanitize_ContainsAllFields()
+        {
+            // Arrange
+            string @event = "test-event";
+            string it = "test-it";
+            string sdk = "csharp";
+            string sdkv = "1.0.0";
+            string sk = "sk_test_123";
+            var payload = new Dictionary<string, string> 
+            {
+                { "key1", "value1" }, 
+                { "key2", "value2" }
+            };
+
+            var preparedEvent = new PreparedEvent(@event, it, sdk, sdkv, sk, payload);
+
+            // Act
+            var sanitized = preparedEvent.Sanitize();
+
+            // Assert
+            Assert.Equal(@event, sanitized["event"]);
+            Assert.Equal(it, sanitized["it"]);
+            Assert.Equal(sdk, sanitized["sdk"]);
+            Assert.Equal(sdkv, sanitized["sdkv"]);
+            Assert.Equal("value1", sanitized["key1"]);
+            Assert.Equal("value2", sanitized["key2"]);
+        }
+
+        [Fact]
+        public void Sanitize_DoesNotIncludeSk()
+        {
+            // Arrange
+            var preparedEvent = new PreparedEvent(
+                "test-event",
+                "test-it",
+                "csharp",
+                "1.0.0",
+                "sk_test_123",
+                new Dictionary<string, string>()
+            );
+
+            // Act
+            var sanitized = preparedEvent.Sanitize();
+
+            // Assert
+            Assert.False(sanitized.ContainsKey("sk"), "SK should not be included in sanitized output");
+        }
+
+        [Fact]
+        public void Sanitize_PayloadOverridesDefaultFields()
+        {
+            // This is a negative test
+            // It's not that we want this behavior so much as we want to document it
+            // Arrange
+            var payload = new Dictionary<string, string>
+            {
+                { "event", "overridden-event" },
+                { "sdk", "overridden-sdk" }
+            };
+
+            var preparedEvent = new PreparedEvent(
+                "original-event",
+                "test-it",
+                "original-sdk",
+                "1.0.0",
+                "sk_test_123",
+                payload
+            );
+
+            // Act
+            var sanitized = preparedEvent.Sanitize();
+
+            // Assert
+            Assert.Equal("overridden-event", sanitized["event"]);
+            Assert.Equal("overridden-sdk", sanitized["sdk"]);
+        }
+
+        [Fact]
+        public void Sanitize_HandlesEmptyPayload()
+        {
+            // Arrange
+            var preparedEvent = new PreparedEvent(
+                "test-event",
+                "test-it",
+                "csharp",
+                "1.0.0",
+                "sk_test_123",
+                new Dictionary<string, string>()
+            );
+
+            // Act
+            var sanitized = preparedEvent.Sanitize();
+
+            // Assert
+            Assert.Equal(4, sanitized.Count);
+            Assert.Equal("test-event", sanitized["event"]);
+            Assert.Equal("test-it", sanitized["it"]);
+            Assert.Equal("csharp", sanitized["sdk"]);
+            Assert.Equal("1.0.0", sanitized["sdkv"]);
+        }
+
+        [Fact]
+        public void Sanitize_SortsKeys()
+        {
+            // Arrange
+            var payload = new Dictionary<string, string>
+            {
+                { "z-key", "z-value" },
+                { "a-key", "a-value" },
+                { "m-key", "m-value" }
+            };
+
+            var preparedEvent = new PreparedEvent(
+                "test-event",
+                "test-it",
+                "csharp",
+                "1.0.0",
+                "sk_test_123",
+                payload
+            );
+
+            // Act
+            var sanitized = preparedEvent.Sanitize();
+
+            // Assert
+            // SortedDictionary sorts keys alphabetically
+            var expectedOrder = new[] { "a-key", "event", "it", "m-key", "sdk", "sdkv", "z-key" };
+            var actualKeys = new string[sanitized.Count];
+            sanitized.Keys.CopyTo(actualKeys, 0);
+
+            Assert.Equal(expectedOrder, actualKeys);
+        }
+    }
+}

--- a/tests/Telemetry/TelemetryCollectorTests.cs
+++ b/tests/Telemetry/TelemetryCollectorTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Clerk.BackendAPI.Hooks.Telemetry;
+using Xunit;
+
+namespace Tests.Telemetry
+{
+    public class TelemetryCollectorTests
+    {
+        [Fact]
+        public void BaseCollector_CollectIgnoresProductionEvents()
+        {
+            // Arrange
+            var prodEvent = new TelemetryEvent(
+                "sk_live_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method" } },
+                1.0f
+            );
+
+            var collector = new TestCollector();
+
+            // Act
+            collector.Collect(prodEvent);
+
+            // Assert
+            Assert.False(collector.WasCollectInternalCalled, "collectInternal should not be called for production events");
+        }
+
+        [Fact]
+        public void BaseCollector_CollectCallsCollectInternalForDevelopment()
+        {
+            // Arrange
+            var devEvent = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method" } },
+                1.0f
+            );
+
+            var collector = new TestCollector();
+
+            // Act
+            collector.Collect(devEvent);
+
+            // Assert
+            Assert.True(collector.WasCollectInternalCalled, "collectInternal should be called for development events");
+            Assert.Equal(devEvent, collector.LastEvent);
+        }
+
+        [Fact]
+        public void BaseCollector_PrepareEventPopulatesAllFields()
+        {
+            // Arrange
+            var event1 = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "key1", "value1" } },
+                1.0f
+            );
+
+            var collector = new TestCollector();
+
+            // Act
+            PreparedEvent prepared = collector.PrepareEventForTest(event1);
+
+            // Assert
+            Assert.Equal(event1.Event, prepared.Event);
+            Assert.Equal(event1.It, prepared.It);
+            Assert.NotNull(prepared.Sdk);
+            Assert.NotNull(prepared.Sdkv);
+            Assert.Equal(event1.Sk, prepared.Sk);
+            Assert.IsType<Dictionary<string, string>>(prepared.Payload);
+            Assert.Equal("value1", prepared.Payload["key1"]);
+        }
+        
+        [Fact]
+        public void DebugCollector_OutputsToConsole()
+        {
+            // Arrange
+            var event1 = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method" } },
+                1.0f
+            );
+
+            var collector = new TestDebugCollector();
+            var consoleOutput = new StringWriter();
+            Console.SetError(consoleOutput);
+
+            try
+            {
+                // Act
+                collector.CollectInternalForTest(event1);
+
+                // Assert
+                string output = consoleOutput.ToString();
+                Assert.Contains(collector.SerializedOutput, output);
+            }
+            finally
+            {
+                Console.SetError(Console.Error);
+            }
+        }
+
+        [Fact]
+        public void DebugCollector_HandlesSerializationError()
+        {
+            // Arrange
+            var event1 = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method" } },
+                1.0f
+            );
+
+            var collector = new TestDebugCollector { ThrowOnSerialize = true };
+            var consoleOutput = new StringWriter();
+            Console.SetError(consoleOutput);
+
+            try
+            {
+                // Act
+                collector.CollectInternalForTest(event1);
+
+                // Assert
+                string output = consoleOutput.ToString();
+                Assert.Contains("Failed to serialize event", output);
+            }
+            finally
+            {
+                Console.SetError(Console.Error);
+            }
+        }
+
+        // Helper test classes
+        private class TestCollector : BaseTelemetryCollector
+        {
+            public bool WasCollectInternalCalled { get; private set; }
+            public TelemetryEvent LastEvent { get; private set; }
+
+            protected override void CollectInternal(TelemetryEvent @event)
+            {
+                WasCollectInternalCalled = true;
+                LastEvent = @event;
+            }
+
+            public PreparedEvent PrepareEventForTest(TelemetryEvent @event)
+            {
+                return PrepareEvent(@event);
+            }
+        }
+
+        private class TestDebugCollector : DebugTelemetryCollector
+        {
+            public bool ThrowOnSerialize { get; set; }
+            public string SerializedOutput { get; } = "{\"test\":\"json\"}";
+
+            protected override string SerializeToJson(PreparedEvent preparedEvent)
+            {
+                if (ThrowOnSerialize)
+                {
+                    throw new Exception("Test error");
+                }
+                return SerializedOutput;
+            }
+
+            public void CollectInternalForTest(TelemetryEvent @event)
+            {
+                CollectInternal(@event);
+            }
+        }
+    }
+}

--- a/tests/Telemetry/TelemetryEventTests.cs
+++ b/tests/Telemetry/TelemetryEventTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using Clerk.BackendAPI.Hooks;
+using Clerk.BackendAPI.Hooks.Telemetry;
+using Clerk.BackendAPI.Utils;
+using Xunit;
+
+namespace Tests.Telemetry
+{
+    public class TelemetryEventTests
+    {
+        [Fact]
+        public void Constructor_InitializesAllFields()
+        {
+            // Arrange
+            string sk = "sk_test_123";
+            string @event = TelemetryEvent.EVENT_METHOD_CALLED;
+            var payload = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            float samplingRate = 0.5f;
+
+            // Act
+            var telemetryEvent = new TelemetryEvent(sk, @event, payload, samplingRate);
+
+            // Assert
+            Assert.Equal(sk, telemetryEvent.Sk);
+            Assert.Equal("development", telemetryEvent.It);
+            Assert.Equal(@event, telemetryEvent.Event);
+            Assert.Equal(payload, telemetryEvent.Payload);
+            Assert.Equal(samplingRate, telemetryEvent.SamplingRate);
+        }
+
+        [Theory]
+        [InlineData("sk_test_123", "development")]
+        [InlineData("sk_test_abc", "development")]
+        [InlineData("sk_live_456", "production")]
+        [InlineData("sk_123", "production")]
+        [InlineData(null, "production")]
+        public void Constructor_SetsItBasedOnSk(string sk, string expectedIt)
+        {
+            // Arrange & Act
+            var telemetryEvent = new TelemetryEvent(
+                sk,
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string>(),
+                0.5f
+            );
+
+            // Assert
+            Assert.Equal(expectedIt, telemetryEvent.It);
+        }
+
+        [Fact]
+        public void FromContext_EmptyAdditionalPayload()
+        {
+            // Arrange
+            string operationId = "testOperation";
+            var emptyPayload = new Dictionary<string, string>();
+            float samplingRate = 0.1f;
+
+            var context = new TestHookContext(operationId, null);
+
+            // Act
+            var @event = TelemetryEvent.FromContext(
+                context,
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                samplingRate,
+                emptyPayload
+            );
+
+            // Assert
+            Assert.Single(@event.Payload);
+            Assert.Equal("testOperation", @event.Payload["method"]);
+        }
+
+        [Fact]
+        public void FromContext_AdditionalPayloadOverridesMethod()
+        {
+            // Not so much behavior we desire as documentation that this occurs
+            // Arrange
+            string operationId = "testOperation";
+            var overridingPayload = new Dictionary<string, string>
+            {
+                { "method", "overridden-method" }
+            };
+            float samplingRate = 0.5f;
+
+            var context = new TestHookContext(operationId, null);
+
+            // Act
+            var @event = TelemetryEvent.FromContext(
+                context,
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                samplingRate,
+                overridingPayload
+            );
+
+            // Assert
+            Assert.Single(@event.Payload);
+            Assert.Equal("overridden-method", @event.Payload["method"]);
+        }
+
+        // Test implementation for HookContext
+        private class TestHookContext : HookContext
+        {
+            public TestHookContext(string operationId, Func<object> securitySource)
+                : base(operationId, null, securitySource)
+            {
+            }
+        }
+    }
+}

--- a/tests/Telemetry/TelemetryHooksTests.cs
+++ b/tests/Telemetry/TelemetryHooksTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Clerk.BackendAPI.Hooks;
+using Clerk.BackendAPI.Hooks.Telemetry;
+using Xunit;
+
+namespace Tests.Telemetry
+{
+    public class TelemetryHooksTests
+    {
+        [Fact]
+        public async Task TelemetryBeforeRequestHook_CollectsEvent()
+        {
+            // Arrange
+            var collector = new TestCollector();
+            var hook = new TelemetryBeforeRequestHook(new List<ITelemetryCollector> { collector });
+            
+            var context = new BeforeRequestContext(new HookContext("testOperation", null, null));
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+
+            // Act
+            await hook.BeforeRequestAsync(context, request);
+
+            // Assert
+            Assert.Equal(1, collector.Events.Count);
+            Assert.Equal(TelemetryEvent.EVENT_METHOD_CALLED, collector.Events[0].Event);
+            Assert.Equal("testOperation", collector.Events[0].Payload["method"]);
+        }
+
+        [Fact]
+        public async Task TelemetryAfterSuccessHook_CollectsEventWithStatusCode()
+        {
+            // Arrange
+            var collector = new TestCollector();
+            var hook = new TelemetryAfterSuccessHook(new List<ITelemetryCollector> { collector });
+            
+            var context = new AfterSuccessContext(new HookContext("testOperation", null, null));
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            // Act
+            await hook.AfterSuccessAsync(context, response);
+
+            // Assert
+            Assert.Equal(1, collector.Events.Count);
+            Assert.Equal(TelemetryEvent.EVENT_METHOD_SUCCEEDED, collector.Events[0].Event);
+            Assert.Equal("testOperation", collector.Events[0].Payload["method"]);
+            Assert.Equal("200", collector.Events[0].Payload["status_code"]);
+        }
+
+        [Fact]
+        public async Task TelemetryAfterErrorHook_CollectsEventWithStatusCode()
+        {
+            // Arrange
+            var collector = new TestCollector();
+            var hook = new TelemetryAfterErrorHook(new List<ITelemetryCollector> { collector });
+            
+            var context = new AfterErrorContext(new HookContext("testOperation", null, null));
+            var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+
+            // Act
+            await hook.AfterErrorAsync(context, response, null);
+
+            // Assert
+            Assert.Equal(1, collector.Events.Count);
+            Assert.Equal(TelemetryEvent.EVENT_METHOD_FAILED, collector.Events[0].Event);
+            Assert.Equal("testOperation", collector.Events[0].Payload["method"]);
+            Assert.Equal("400", collector.Events[0].Payload["status_code"]);
+        }
+
+        [Fact]
+        public async Task TelemetryAfterErrorHook_CollectsEventWithErrorMessage()
+        {
+            // Arrange
+            var collector = new TestCollector();
+            var hook = new TelemetryAfterErrorHook(new List<ITelemetryCollector> { collector });
+            
+            var context = new AfterErrorContext(new HookContext("testOperation", null, null));
+            var error = new Exception("Test error message");
+
+            // Act
+            await hook.AfterErrorAsync(context, null, error);
+
+            // Assert
+            Assert.Equal(1, collector.Events.Count);
+            Assert.Equal(TelemetryEvent.EVENT_METHOD_FAILED, collector.Events[0].Event);
+            Assert.Equal("testOperation", collector.Events[0].Payload["method"]);
+            Assert.Equal("Test error message", collector.Events[0].Payload["error_message"]);
+        }
+
+        // Helper test class
+        private class TestCollector : ITelemetryCollector
+        {
+            public List<TelemetryEvent> Events { get; } = new List<TelemetryEvent>();
+
+            public void Collect(TelemetryEvent @event)
+            {
+                Events.Add(@event);
+            }
+        }
+    }
+}

--- a/tests/Telemetry/TelemetrySamplerTests.cs
+++ b/tests/Telemetry/TelemetrySamplerTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using Clerk.BackendAPI.Hooks.Telemetry;
+using Xunit;
+
+namespace Tests.Telemetry
+{
+    public class TelemetrySamplerTests
+    {
+        private static TelemetryEvent CreateTestEvent(float samplingRate)
+        {
+            return new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method" } },
+                samplingRate
+            );
+        }
+
+        private static PreparedEvent CreateTestPreparedEvent(TelemetryEvent @event)
+        {
+            return new PreparedEvent(@event.Event, @event.It, "sdk", "sdkv", @event.Sk, @event.Payload);
+        }
+
+        [Fact]
+        public void RandomSampler_WithSeedWorks()
+        {
+            // Arrange
+            var fixedRandom = new Random(1);
+            var sampler = new RandomSampler(fixedRandom);
+
+            var @event = CreateTestEvent(0.5f);
+            var preparedEvent = CreateTestPreparedEvent(@event);
+
+            // Act - with a fixed seed, we should get deterministic results
+            bool firstResult = sampler.Test(preparedEvent, @event);
+            bool secondResult = sampler.Test(preparedEvent, @event);
+
+            // The exact results will depend on the random seed, but we can at least verify they're different
+            // With seed 1, these should be predictable
+            Assert.NotEqual(firstResult, secondResult);
+        }
+
+        [Fact]
+        public void RandomSampler_SamplingRateZero_AlwaysFalse()
+        {
+            // Arrange
+            var sampler = new RandomSampler(new Random());
+
+            // Act & Assert
+            for (int i = 0; i < 100; i++)
+            {
+                var @event = CreateTestEvent(0.0f);
+                var preparedEvent = CreateTestPreparedEvent(@event);
+                Assert.False(sampler.Test(preparedEvent, @event), "Should always return false with 0.0 sampling rate");
+            }
+        }
+
+        [Fact]
+        public void RandomSampler_SamplingRateOne_AlwaysTrue()
+        {
+            // Arrange
+            var sampler = new RandomSampler(new Random());
+
+
+            // Act & Assert
+            for (int i = 0; i < 100; i++)
+            {
+                var @event = CreateTestEvent(1.0f);
+                var preparedEvent = CreateTestPreparedEvent(@event);
+                Assert.True(sampler.Test(preparedEvent, @event), "Should always return true with 1.0 sampling rate");
+            }
+        }
+
+        [Fact]
+        public void DeduplicatingSampler_FirstEventAccepted()
+        {
+            // Arrange
+            DateTime fixedTime = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var sampler = new DeduplicatingSampler(
+                TimeSpan.FromDays(1),
+                () => fixedTime
+            );
+
+            var @event = CreateTestEvent(0.5f);
+            var preparedEvent = CreateTestPreparedEvent(@event);
+
+            // Act & Assert
+            Assert.True(sampler.Test(preparedEvent, @event), "First event should be accepted");
+        }
+
+        [Fact]
+        public void DeduplicatingSampler_DuplicateEventWithinWindowRejected()
+        {
+            // Arrange
+            var testClock = new TestClock(new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+            var sampler = new DeduplicatingSampler(
+                TimeSpan.FromDays(1),
+                testClock.GetCurrentTime
+            );
+
+            var @event = CreateTestEvent(0.5f);
+            var preparedEvent = CreateTestPreparedEvent(@event);
+
+            // Act
+            bool firstResult = sampler.Test(preparedEvent, @event);
+
+            // Move time forward, but still within window
+            testClock.SetCurrentTime(testClock.CurrentTime.AddHours(23));
+
+            bool secondResult = sampler.Test(preparedEvent, @event);
+
+            // Assert
+            Assert.True(firstResult, "First event should be accepted");
+            Assert.False(secondResult, "Duplicate event within window should be rejected");
+        }
+
+        [Fact]
+        public void DeduplicatingSampler_EventAfterWindowAccepted()
+        {
+            // Arrange
+            var testClock = new TestClock(new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+            var sampler = new DeduplicatingSampler(
+                TimeSpan.FromDays(1),
+                testClock.GetCurrentTime
+            );
+
+            var @event = CreateTestEvent(0.5f);
+            var preparedEvent = CreateTestPreparedEvent(@event);
+
+            // Act
+            bool firstResult = sampler.Test(preparedEvent, @event);
+
+            // Move time forward beyond window
+            testClock.SetCurrentTime(testClock.CurrentTime.AddHours(25));
+
+            bool secondResult = sampler.Test(preparedEvent, @event);
+
+            // Assert
+            Assert.True(firstResult, "First event should be accepted");
+            Assert.True(secondResult, "Event after window should be accepted");
+        }
+
+        [Fact]
+        public void DeduplicatingSampler_DifferentEventsAccepted()
+        {
+            // Arrange
+            DateTime fixedTime = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var sampler = new DeduplicatingSampler(
+                TimeSpan.FromDays(1),
+                () => fixedTime
+            );
+
+            var firstEvent = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method-1" } },
+                0.5f
+            );
+            var firstPreparedEvent = CreateTestPreparedEvent(firstEvent);
+
+            var secondEvent = new TelemetryEvent(
+                "sk_test_123",
+                TelemetryEvent.EVENT_METHOD_CALLED,
+                new Dictionary<string, string> { { "method", "test-method-2" } },
+                0.5f
+            );
+            var secondPreparedEvent = CreateTestPreparedEvent(secondEvent);
+
+            // Act
+            bool firstResult = sampler.Test(firstPreparedEvent, firstEvent);
+            bool secondResult = sampler.Test(secondPreparedEvent, secondEvent);
+
+            // Assert
+            Assert.True(firstResult, "First event should be accepted");
+            Assert.True(secondResult, "Different event should be accepted");
+        }
+
+        // A test clock implementation that allows changing the time
+        private class TestClock
+        {
+            public DateTime CurrentTime { get; private set; }
+
+            public TestClock(DateTime initialTime)
+            {
+                CurrentTime = initialTime;
+            }
+
+            public void SetCurrentTime(DateTime newTime)
+            {
+                CurrentTime = newTime;
+            }
+
+            public DateTime GetCurrentTime()
+            {
+                return CurrentTime;
+            }
+        }
+    }
+}


### PR DESCRIPTION
A port of https://github.com/clerk/clerk-sdk-java/pull/53 to C#.

<details><summary>Example messages</summary>

```
Mar 06 16:10:37 --> {"event":"METHOD_CALLED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0"}
Mar 06 16:10:38 [server] event: connection (socket#26)
Mar 06 16:10:38 [socket#26] event: resume
Mar 06 16:10:38 [socket#26] event: data
Mar 06 16:10:38 --> POST / HTTP/1.1
Mar 06 16:10:38 --> Host: localhost:3000
Mar 06 16:10:38 --> Content-Type: application/json; charset=utf-8
Mar 06 16:10:38 --> Content-Length: 138
Mar 06 16:10:38 -->
Mar 06 16:10:38 --> {"event":"METHOD_SUCCEEDED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0","status_code":"200"}
```

</details>

<details><summary>Example hook exerciser</summary>

```
using System;
using System.Linq;
using System.Threading.Tasks;
using Clerk.BackendAPI;

namespace TestClerkCSharp
{
    class Program
    {
        static async Task Main(string[] args)
        {
            var apiKey = "sk_test_D0BcXJScgo4bad1GSfaCmVbo9jqZvW2msRc5P61l0q";
            
            Console.WriteLine("=== Testing with Clerk.BackendAPI ===");
            
            try
            {
                var spk = new ClerkBackendApi(bearerAuth: apiKey);

                var users = await spk.Users.ListAsync();
                if (users?.UserList != null)
                {
                    Console.WriteLine($"Found {users.UserList.Count} users:");
                    foreach (var user in users.UserList)
                    {
                        Console.WriteLine($"- User ID: {user.Id}, Email: {user.EmailAddresses?.FirstOrDefault()?.ToString() ?? "No email"}, Created: {user.CreatedAt}");
                    }
                }
                else
                {
                    Console.WriteLine("No users found or UserList is null.");
                }
            }
            catch (Exception ex)
            {
                Console.WriteLine($"Error: {ex.Message}");
            }
        }
    }
}
```

</details>

## Summary

We're adding

* Three Speakeasy hooks:
  - Not SDKInit because that isn't yet supported for us because we can't get to the sk yet
* A random sampler that filters out 90% of events
* A deduplication sampler that ensures that a single process only fires one event per day
* Skipping via CLERK_TELEMETRY_DISABLED=1
* Debugging via CLERK_TELEMETRY_DEBUG=1
* A few unit tests for each of the bits.
* A minor switch to not use the `async` keyword on the existing hook since it propagates a warning but you can just use `Task.from` to wrap it in the format we want

## Slightly related change
It would be useful for the C# generated code to type `SecuritySource` better in the `HookContext` because we have a type-check and cast to do at runtime right now.

## Output 

<details><summary>Debug Logs</summary>

```
➜  test-clerk-csharp git:(main) ✗ CLERK_TELEMETRY_DEBUG=1 dotnet run
=== Testing with Clerk.BackendAPI ===
{"event":"METHOD_CALLED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0"}
{"event":"METHOD_SUCCEEDED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0","status_code":"200"}
Found 1 users:
- User ID: user_2tpc6ErDIdl5f52i6iFbVcRXxKe, Email: Clerk.BackendAPI.Models.Components.EmailAddress, Created: 1741052278846
```

</details>

<details><summary>HTTP Echo Server Logs</summary>

```
Mar 06 16:17:12 --> {"event":"METHOD_CALLED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0"}
Mar 06 16:17:13 [server] event: connection (socket#28)
Mar 06 16:17:13 [socket#28] event: resume
Mar 06 16:17:13 [socket#28] event: data
Mar 06 16:17:13 --> POST / HTTP/1.1
Mar 06 16:17:13 --> Host: localhost:3000
Mar 06 16:17:13 --> Content-Type: application/json; charset=utf-8
Mar 06 16:17:13 --> Content-Length: 138
Mar 06 16:17:13 -->
Mar 06 16:17:13 --> {"event":"METHOD_SUCCEEDED","it":"development","method":"GetUserList","sdk":"Clerk:Clerk.BackendAPI","sdkv":"0.6.1.0","status_code":"200"}
```

</details>